### PR TITLE
added first version of jhbuild support for buzztrax

### DIFF
--- a/buildtools/jhbuild/buzztrax.jhbuild.rc
+++ b/buildtools/jhbuild/buzztrax.jhbuild.rc
@@ -1,0 +1,11 @@
+moduleset = os.path.expanduser('~/buzztrax/jhbuild/buzztrax.modules')
+modules = [ 'buzztrax-all' ]
+checkoutroot = os.path.expanduser('~/buzztrax/jhbuild/build')
+prefix = os.path.expanduser('~/buzztrax/jhbuild/install')
+
+autogenargs = ''
+
+os.environ['ACLOCAL'] = 'aclocal -I ' + prefix + '/share/aclocal/'
+os.environ['GST_PLUGIN_PATH'] = prefix + '/lib/gstreamer-0.10/'
+#os.environ['XDG_DATA_DIRS'] = os.environ['XDG_DATA_DIRS'] + ":" + prefix + '/share/'
+addpath('PKG_CONFIG_PATH', os.path.expanduser('~/buzztrax/jhbuild/install/lib/pkgconfig'))

--- a/buildtools/jhbuild/buzztrax.modules
+++ b/buildtools/jhbuild/buzztrax.modules
@@ -1,0 +1,62 @@
+<?xml version="1.0" standalone="no"?> <!--*- mode: nxml -*-->
+
+<!DOCTYPE moduleset SYSTEM "moduleset.dtd">
+<?xml-stylesheet type="text/xsl" href="moduleset.xsl"?>
+<moduleset>
+  <repository type="git" name="github" href="https://github.com/"/>
+  <repository type="git" name="gstreamer.freedesktop.org" href="git://anongit.freedesktop.org/gstreamer/"/>
+
+  <autotools id="gstreamer-1.0"
+             autogenargs="--disable-tests --disable-fatal-warnings"
+             supports-non-srcdir-builds="no">
+    <branch repo="gstreamer.freedesktop.org"
+            module="gstreamer"
+            revision="1.1.90"
+            checkoutdir="gstreamer-1.0"/>
+  </autotools>
+
+  <autotools id="gst-plugins-base-1.0"
+             autogenargs="--disable-tests --disable-fatal-warnings"
+             supports-non-srcdir-builds="no">
+    <dependencies>
+      <dep package="gstreamer-1.0"/>
+    </dependencies>
+    <branch repo="gstreamer.freedesktop.org"
+            module="gst-plugins-base"
+            revision="1.1.90"
+            checkoutdir="gst-plugins-base-1.0"/>
+  </autotools>
+
+  <autotools id="bml">
+    <branch repo="github" module="Buzztrax/bml.git" checkoutdir="bml"/>
+  </autotools>
+
+  <autotools id="gst-buzztrax">
+    <dependencies>
+      <dep package="gstreamer-1.0"/>
+      <dep package="gst-plugins-base-1.0"/>
+      <dep package="bml"/>
+    </dependencies>
+    <branch repo="github" module="Buzztrax/gst-buzztrax.git" checkoutdir="gst-buzztrax"/>
+  </autotools>
+
+  <autotools id="buzztrax">
+    <dependencies>
+      <dep package="gst-buzztrax"/>
+    </dependencies>
+    <branch repo="github" module="Buzztrax/buzztrax.git" checkoutdir="buzztrax"/>
+  </autotools>
+
+  <autotools id="buzzmachines">
+    <branch repo="github" module="Buzztrax/buzzmachines.git" checkoutdir="buzzmachines"/>
+  </autotools>
+
+
+  <metamodule id="buzztrax-all">
+    <dependencies>
+      <dep package="buzztrax"/>
+      <dep package="buzzmachines"/>
+    </dependencies>
+  </metamodule>
+
+</moduleset>


### PR DESCRIPTION
@ensonic can you please take a look and possible merge/comment?

Currently I do not know why we need the (not working) XDG_DATA_DIRS ... but also buzztrax does not compile clean.

But this can be used as a good starting point.

I have used gstreamer as additional module and used version 1.1.90. Please be aware of this.

Thanks,
- waffel
