### PR TITLE
Remove USE_BML ifdef. BML is no longer optional?

### DIFF
--- a/src/lib/core/buzzcallbacks.c
+++ b/src/lib/core/buzzcallbacks.c
@@ -19,9 +19,8 @@
 #define BT_BUZZCALLBACKS_C
 
 #include "core_private.h"
-#ifdef USE_BML
 // for CHostCallbacks
-#include <libbml/bml.h>
+#include "bml/bml.h"
 
 /*
  * we could use some static hashtables to cache the returned structs
@@ -216,8 +215,6 @@ static CHostCallbacks callbacks = {
   GetNearestWaveLevel
 };
 
-#endif
-
 /**
  * bt_buzz_callbacks_get:
  * @song: the song for the callback context
@@ -229,10 +226,6 @@ static CHostCallbacks callbacks = {
 gpointer
 bt_buzz_callbacks_get (BtSong * song)
 {
-#ifdef USE_BML
   callbacks.user_data = (gpointer) song;
   return &callbacks;
-#else
-  return NULL;
-#endif
 }


### PR DESCRIPTION
I forgot this one before. 

I found that Buzz machines weren't receiving their host_callbacks because of this.

For instance, Matilde Tracker would receive no samples.

I'm guessing that the USE_BML ifdef no longer applies now that BML is integrated into the main project?