### PR TITLE
Use NEWS date instead of build date

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -52,8 +52,8 @@ AC_SUBST(GST_MAJORMINOR)
 dnl release year and date
 DATE_STAMP=`head -n1 "${srcdir}/NEWS" | sed -e 's/^.*(\([[^\)]]*\)).*$/\1/'`
 if test "$DATE_STAMP" == "XX.XXX.XXXX"; then
-  BT_RELEASE_YEAR=`date +%Y`
-  BT_RELEASE_DATE=`date +%Y-%m-%d`
+  BT_RELEASE_YEAR=`date -u -r NEWS +%Y`
+  BT_RELEASE_DATE=`date -u -r NEWS +%Y-%m-%d`
 else
   IFS="." read -r d m y <<< "$DATE_STAMP"
   BT_RELEASE_YEAR="$y"


### PR DESCRIPTION
Use ChangeLog date instead of build date
to make builds reproducible.
See https://reproducible-builds.org/ for why this is good.

This date call works with GNU date and (some?) BSD date.

Unfortunately, the ChangeLog files seems to not get updated often.

One alternative would be to use [`SOURCE_DATE_EPOCH`](https://reproducible-builds.org/docs/source-date-epoch/#bash--posix-shell)

another way is to update these values as constants with a script in git before release