### PR TITLE
serialization: Don't save or restore NULL or unparsable types

### DIFF
--- a/Makefile.src.am
+++ b/Makefile.src.am
@@ -743,11 +743,9 @@ if WITH_UPDATE_MIME
 endif
 
 if USE_GIR
-libbtcore_gir_sources=$(patsubst %,$(srcdir)/%, $(libbuzztrax_core_la_SOURCES))
-libbtcore_gir_headers=$(patsubst %,$(srcdir)/%, $(libbuzztrax_core_HEADERS))
 
-BuzztraxCore-@BT_MAJORMINOR@.gir: $(G_IR_SCANNER) libbuzztrax-core.la BuzztraxIc-@BT_MAJORMINOR@.gir
-	-$(AM_V_GEN)PKG_CONFIG_PATH="$(PKG_CONFIG_PATH):$(top_srcdir)/src/lib/ic/" $(G_IR_SCANNER) -v \
+BuzztraxCore-@BT_MAJORMINOR@.gir: $(libbuzztrax_core_la_SOURCES) $(libbuzztrax_core_HEADERS) BuzztraxIc-@BT_MAJORMINOR@.gir | $(G_IR_SCANNER) libbuzztrax-core.la
+	$(AM_V_GEN)PKG_CONFIG_PATH="$(PKG_CONFIG_PATH):$(top_srcdir)/src/lib/ic/" $(G_IR_SCANNER) -v \
 	   --namespace=BuzztraxCore \
 	   --nsversion @BT_MAJORMINOR@ \
 	   --warn-all \
@@ -771,19 +769,17 @@ BuzztraxCore-@BT_MAJORMINOR@.gir: $(G_IR_SCANNER) libbuzztrax-core.la BuzztraxIc
 	   --pkg libxml-2.0 \
 	   --pkg gstreamer-@GST_MAJORMINOR@ \
 	   --pkg-export libbuzztrax-core \
-	   --add-init-section="bt_init(NULL,NULL);" \
+	   --add-init-section="void bt_init (gint * argc, gchar ** argv[]); bt_init(NULL,NULL);" \
 	   --output $@ \
-	   $(libbtcore_gir_sources) $(libbtcore_gir_headers) || touch $@
+	   $^
 
-libbtic_gir_sources=$(patsubst %,$(srcdir)/%, $(libbuzztrax_ic_la_SOURCES))
-libbtic_gir_headers=$(patsubst %,$(srcdir)/%, $(libbuzztrax_ic_HEADERS))
-
-BuzztraxIc-@BT_MAJORMINOR@.gir: $(G_IR_SCANNER) libbuzztrax-ic.la
-	-$(AM_V_GEN)$(G_IR_SCANNER) -v \
+BuzztraxIc-@BT_MAJORMINOR@.gir: $(libbuzztrax_ic_la_SOURCES) $(libbuzztrax_ic_HEADERS) | $(G_IR_SCANNER) libbuzztrax-ic.la 
+	$(AM_V_GEN)$(G_IR_SCANNER) -v \
 	   --namespace=BuzztraxIc \
 	   --nsversion @BT_MAJORMINOR@ \
 	   --warn-all \
-	   -I$(builddir) \
+	   -I$(abs_top_builddir) \
+	   -I$(abs_top_builddir)/src/ \
 	   -I$(srcdir) \
 	   -I$(top_srcdir)/src/lib/ \
 	   --identifier-prefix=BtIc \
@@ -798,9 +794,9 @@ BuzztraxIc-@BT_MAJORMINOR@.gir: $(G_IR_SCANNER) libbuzztrax-ic.la
 	   --pkg gobject-2.0 \
 	   --pkg gstreamer-@GST_MAJORMINOR@ \
 	   --pkg-export libbuzztrax-ic \
-	   --add-init-section="btic_init(NULL,NULL);" \
+	   --add-init-section="void btic_init (gint * argc, gchar ** argv[]); btic_init(NULL,NULL);" \
 	   --output $@ \
-	   $(libbtic_gir_sources) $(libbtic_gir_headers) || touch $@
+	   $^
 
 BUILT_GIRSOURCES = BuzztraxCore-@BT_MAJORMINOR@.gir BuzztraxIc-@BT_MAJORMINOR@.gir
 

--- a/configure.ac
+++ b/configure.ac
@@ -52,8 +52,8 @@ AC_SUBST(GST_MAJORMINOR)
 dnl release year and date
 DATE_STAMP=`head -n1 "${srcdir}/NEWS" | sed -e 's/^.*(\([[^\)]]*\)).*$/\1/'`
 if test "$DATE_STAMP" == "XX.XXX.XXXX"; then
-  BT_RELEASE_YEAR=`date -u -r NEWS +%Y`
-  BT_RELEASE_DATE=`date -u -r NEWS +%Y-%m-%d`
+  BT_RELEASE_YEAR=`date -u -r "${srcdir}/NEWS" +%Y`
+  BT_RELEASE_DATE=`date -u -r "${srcdir}/NEWS" +%Y-%m-%d`
 else
   IFS="." read -r d m y <<< "$DATE_STAMP"
   BT_RELEASE_YEAR="$y"

--- a/docs/help/bt-edit/Makefile.am
+++ b/docs/help/bt-edit/Makefile.am
@@ -12,7 +12,7 @@ HELP_MEDIA += \
 # We have no translation for the manual
 HELP_LINUAGS =
 
-C/version.entities: $(abs_top_srcdir)/docs/version.entities
+C/version.entities: $(abs_top_builddir)/docs/version.entities
 	@cp $< $@
 
 CLEANFILES = C/version.entities

--- a/src/lib/core/song-io-native-xml.c
+++ b/src/lib/core/song-io-native-xml.c
@@ -108,7 +108,7 @@ bt_song_io_native_xml_save (gconstpointer const _self,
     if (root_node) {
       xmlDocSetRootElement (song_doc, root_node);
       if (file_name) {
-        if (xmlSaveFile (file_name, song_doc) != -1) {
+        if (xmlSaveFormatFile (file_name, song_doc, 1) != -1) {
           result = TRUE;
           GST_INFO ("xml saved okay");
         } else {


### PR DESCRIPTION
Hello there Stefan, I have a few pull requests to come through. Here's the first.

This was causing the "pulsesrc" machine to fail to initialize on song load.

There are also some small out-of-tree build fixes in this pull request, around GIR file generation, version.entities and calculation of the BT_RELEASE_YEAR from the NEWS file.

Finally, songs are being pretty-printed when saved in XML format, for ease of debugging.