### PR TITLE
Update deprecated use of G_TYPE_INSTANCE_GET_PRIVATE()

### DIFF
--- a/src/lib/core/application.c
+++ b/src/lib/core/application.c
@@ -61,7 +61,8 @@ struct _BtApplicationPrivate
 
 //-- the class
 
-G_DEFINE_ABSTRACT_TYPE (BtApplication, bt_application, G_TYPE_OBJECT);
+G_DEFINE_ABSTRACT_TYPE_WITH_CODE (BtApplication, bt_application, G_TYPE_OBJECT, 
+    G_ADD_PRIVATE(BtApplication));
 
 //-- helper
 
@@ -141,9 +142,7 @@ bt_application_init (BtApplication * self)
   GstBus *bus;
 
   GST_DEBUG ("!!!! self=%p", self);
-  self->priv =
-      G_TYPE_INSTANCE_GET_PRIVATE (self, BT_TYPE_APPLICATION,
-      BtApplicationPrivate);
+  self->priv = bt_application_get_instance_private(self);;
   self->priv->bin = gst_pipeline_new ("song");
   g_assert (GST_IS_ELEMENT (self->priv->bin));
   GST_DEBUG ("bin: %" G_OBJECT_REF_COUNT_FMT,
@@ -171,7 +170,6 @@ bt_application_class_init (BtApplicationClass * const klass)
   GObjectClass *const gobject_class = G_OBJECT_CLASS (klass);
 
   GST_DEBUG ("!!!!");
-  g_type_class_add_private (klass, sizeof (BtApplicationPrivate));
 
   gobject_class->get_property = bt_application_get_property;
   gobject_class->dispose = bt_application_dispose;

--- a/src/lib/core/audio-session.c
+++ b/src/lib/core/audio-session.c
@@ -67,7 +67,8 @@ static BtAudioSession *singleton = NULL;
 
 //-- the class
 
-G_DEFINE_TYPE (BtAudioSession, bt_audio_session, G_TYPE_OBJECT);
+G_DEFINE_TYPE_WITH_CODE (BtAudioSession, bt_audio_session, G_TYPE_OBJECT, 
+    G_ADD_PRIVATE(BtAudioSession));
 
 //-- signal handlers
 
@@ -373,9 +374,7 @@ bt_audio_session_finalize (GObject * const object)
 static void
 bt_audio_session_init (BtAudioSession * self)
 {
-  self->priv =
-      G_TYPE_INSTANCE_GET_PRIVATE (self, BT_TYPE_AUDIO_SESSION,
-      BtAudioSessionPrivate);
+  self->priv = bt_audio_session_get_instance_private(self);
 
   GST_INFO ("!!!! self=%p", self);
 
@@ -394,8 +393,6 @@ static void
 bt_audio_session_class_init (BtAudioSessionClass * klass)
 {
   GObjectClass *const gobject_class = G_OBJECT_CLASS (klass);
-
-  g_type_class_add_private (klass, sizeof (BtAudioSessionPrivate));
 
   gobject_class->constructor = bt_audio_session_constructor;
   gobject_class->set_property = bt_audio_session_set_property;

--- a/src/lib/core/cmd-pattern-control-source.c
+++ b/src/lib/core/cmd-pattern-control-source.c
@@ -62,8 +62,9 @@ struct _BtCmdPatternControlSourcePrivate
 };
 
 //-- the class
-G_DEFINE_TYPE (BtCmdPatternControlSource, bt_cmd_pattern_control_source,
-    GST_TYPE_CONTROL_BINDING);
+G_DEFINE_TYPE_WITH_CODE (BtCmdPatternControlSource, bt_cmd_pattern_control_source,
+    GST_TYPE_CONTROL_BINDING,
+    G_ADD_PRIVATE(BtCmdPatternControlSource));
 
 /**
  * bt_cmd_pattern_control_source_new:
@@ -369,9 +370,7 @@ bt_cmd_pattern_control_source_finalize (GObject * const object)
 static void
 bt_cmd_pattern_control_source_init (BtCmdPatternControlSource * self)
 {
-  self->priv =
-      G_TYPE_INSTANCE_GET_PRIVATE (self, BT_TYPE_CMD_PATTERN_CONTROL_SOURCE,
-      BtCmdPatternControlSourcePrivate);
+  self->priv = bt_cmd_pattern_control_source_get_instance_private(self);
 }
 
 static void
@@ -381,8 +380,6 @@ bt_cmd_pattern_control_source_class_init (BtCmdPatternControlSourceClass *
   GObjectClass *const gobject_class = G_OBJECT_CLASS (klass);
   GstControlBindingClass *control_binding_class =
       (GstControlBindingClass *) klass;
-
-  g_type_class_add_private (klass, sizeof (BtCmdPatternControlSourcePrivate));
 
   control_binding_class->sync_values =
       gst_cmd_pattern_control_source_sync_values;

--- a/src/lib/core/cmd-pattern.c
+++ b/src/lib/core/cmd-pattern.c
@@ -105,7 +105,8 @@ struct _BtCmdPatternPrivate
 
 //-- the class
 
-G_DEFINE_TYPE (BtCmdPattern, bt_cmd_pattern, G_TYPE_OBJECT);
+G_DEFINE_TYPE_WITH_CODE (BtCmdPattern, bt_cmd_pattern, G_TYPE_OBJECT, 
+    G_ADD_PRIVATE(BtCmdPattern));
 
 //-- enums
 
@@ -286,17 +287,13 @@ bt_cmd_pattern_finalize (GObject * const object)
 static void
 bt_cmd_pattern_init (BtCmdPattern * self)
 {
-  self->priv =
-      G_TYPE_INSTANCE_GET_PRIVATE (self, BT_TYPE_CMD_PATTERN,
-      BtCmdPatternPrivate);
+  self->priv = bt_cmd_pattern_get_instance_private(self);
 }
 
 static void
 bt_cmd_pattern_class_init (BtCmdPatternClass * const klass)
 {
   GObjectClass *const gobject_class = G_OBJECT_CLASS (klass);
-
-  g_type_class_add_private (klass, sizeof (BtCmdPatternPrivate));
 
   gobject_class->constructed = bt_cmd_pattern_constructed;
   gobject_class->set_property = bt_cmd_pattern_set_property;

--- a/src/lib/core/machine.c
+++ b/src/lib/core/machine.c
@@ -287,6 +287,7 @@ static void bt_machine_persistence_interface_init (gpointer const g_iface,
     gpointer const iface_data);
 
 G_DEFINE_ABSTRACT_TYPE_WITH_CODE (BtMachine, bt_machine, GST_TYPE_BIN,
+    G_ADD_PRIVATE(BtMachine)
     G_IMPLEMENT_INTERFACE (BT_TYPE_PERSISTENCE,
         bt_machine_persistence_interface_init));
 
@@ -3548,8 +3549,7 @@ bt_machine_finalize (GObject * const object)
 static void
 bt_machine_init (BtMachine * self)
 {
-  self->priv =
-      G_TYPE_INSTANCE_GET_PRIVATE (self, BT_TYPE_MACHINE, BtMachinePrivate);
+  self->priv = bt_machine_get_instance_private(self);
   // default is no voice, only global params
   //self->priv->voices=1;
   self->priv->properties =
@@ -3569,7 +3569,6 @@ bt_machine_class_init (BtMachineClass * const klass)
   GstElementClass *const gstelement_class = GST_ELEMENT_CLASS (klass);
 
   error_domain = g_type_qname (BT_TYPE_MACHINE);
-  g_type_class_add_private (klass, sizeof (BtMachinePrivate));
 
   bt_machine_machine = g_quark_from_static_string ("BtMachine::machine");
   bt_machine_property_name =

--- a/src/lib/core/parameter-group.c
+++ b/src/lib/core/parameter-group.c
@@ -70,7 +70,8 @@ struct _BtParameterGroupPrivate
 
 //-- the class
 
-G_DEFINE_TYPE (BtParameterGroup, bt_parameter_group, G_TYPE_OBJECT);
+G_DEFINE_TYPE_WITH_CODE (BtParameterGroup, bt_parameter_group, G_TYPE_OBJECT, 
+    G_ADD_PRIVATE(BtParameterGroup));
 
 //-- macros
 
@@ -870,9 +871,7 @@ static void
 bt_parameter_group_init (BtParameterGroup * self)
 {
   GST_DEBUG ("!!!! self=%p", self);
-  self->priv =
-      G_TYPE_INSTANCE_GET_PRIVATE (self, BT_TYPE_PARAMETER_GROUP,
-      BtParameterGroupPrivate);
+  self->priv = bt_parameter_group_get_instance_private(self);
 }
 
 static void
@@ -881,7 +880,6 @@ bt_parameter_group_class_init (BtParameterGroupClass * const klass)
   GObjectClass *const gobject_class = G_OBJECT_CLASS (klass);
 
   GST_DEBUG ("!!!!");
-  g_type_class_add_private (klass, sizeof (BtParameterGroupPrivate));
 
   gobject_class->constructed = bt_parameter_group_constructed;
   gobject_class->set_property = bt_parameter_group_set_property;

--- a/src/lib/core/pattern-control-source.c
+++ b/src/lib/core/pattern-control-source.c
@@ -74,8 +74,9 @@ struct _BtPatternControlSourcePrivate
 };
 
 //-- the class
-G_DEFINE_TYPE (BtPatternControlSource, bt_pattern_control_source,
-    GST_TYPE_CONTROL_BINDING);
+G_DEFINE_TYPE_WITH_CODE (BtPatternControlSource, bt_pattern_control_source,
+    GST_TYPE_CONTROL_BINDING,
+    G_ADD_PRIVATE(BtPatternControlSource));
 
 /**
  * bt_pattern_control_source_new:
@@ -440,9 +441,7 @@ bt_pattern_control_source_finalize (GObject * const object)
 static void
 bt_pattern_control_source_init (BtPatternControlSource * self)
 {
-  self->priv =
-      G_TYPE_INSTANCE_GET_PRIVATE (self, BT_TYPE_PATTERN_CONTROL_SOURCE,
-      BtPatternControlSourcePrivate);
+  self->priv = bt_pattern_control_source_get_instance_private(self);
 }
 
 static void
@@ -451,8 +450,6 @@ bt_pattern_control_source_class_init (BtPatternControlSourceClass * const klass)
   GObjectClass *const gobject_class = G_OBJECT_CLASS (klass);
   GstControlBindingClass *control_binding_class =
       (GstControlBindingClass *) klass;
-
-  g_type_class_add_private (klass, sizeof (BtPatternControlSourcePrivate));
 
   control_binding_class->sync_values = gst_pattern_control_source_sync_values;
   control_binding_class->get_value = bt_pattern_control_source_get_value;

--- a/src/lib/core/pattern.c
+++ b/src/lib/core/pattern.c
@@ -113,6 +113,7 @@ static void bt_pattern_persistence_interface_init (gpointer const g_iface,
     gpointer const iface_data);
 
 G_DEFINE_TYPE_WITH_CODE (BtPattern, bt_pattern, BT_TYPE_CMD_PATTERN,
+    G_ADD_PRIVATE(BtPattern)
     G_IMPLEMENT_INTERFACE (BT_TYPE_PERSISTENCE,
         bt_pattern_persistence_interface_init));
 
@@ -1207,8 +1208,7 @@ bt_pattern_finalize (GObject * const object)
 static void
 bt_pattern_init (BtPattern * self)
 {
-  self->priv =
-      G_TYPE_INSTANCE_GET_PRIVATE (self, BT_TYPE_PATTERN, BtPatternPrivate);
+  self->priv = bt_pattern_get_instance_private(self);
   self->priv->wire_value_groups =
       g_hash_table_new_full (NULL, NULL, NULL, (GDestroyNotify) g_object_unref);
   self->priv->param_to_value_groups =
@@ -1219,8 +1219,6 @@ static void
 bt_pattern_class_init (BtPatternClass * const klass)
 {
   GObjectClass *const gobject_class = G_OBJECT_CLASS (klass);
-
-  g_type_class_add_private (klass, sizeof (BtPatternPrivate));
 
   gobject_class->constructed = bt_pattern_constructed;
   gobject_class->set_property = bt_pattern_set_property;

--- a/src/lib/core/sequence.c
+++ b/src/lib/core/sequence.c
@@ -138,6 +138,7 @@ static void bt_sequence_persistence_interface_init (gpointer const g_iface,
     gpointer const iface_data);
 
 G_DEFINE_TYPE_WITH_CODE (BtSequence, bt_sequence, G_TYPE_OBJECT,
+    G_ADD_PRIVATE(BtSequence)
     G_IMPLEMENT_INTERFACE (BT_TYPE_PERSISTENCE,
         bt_sequence_persistence_interface_init));
 
@@ -1781,8 +1782,7 @@ bt_sequence_finalize (GObject * const object)
 static void
 bt_sequence_init (BtSequence * self)
 {
-  self->priv =
-      G_TYPE_INSTANCE_GET_PRIVATE (self, BT_TYPE_SEQUENCE, BtSequencePrivate);
+  self->priv = bt_sequence_get_instance_private(self);
   self->priv->loop_start = -1;
   self->priv->loop_end = -1;
   self->priv->pattern_usage = g_hash_table_new (NULL, NULL);
@@ -1794,8 +1794,6 @@ static void
 bt_sequence_class_init (BtSequenceClass * const klass)
 {
   GObjectClass *const gobject_class = G_OBJECT_CLASS (klass);
-
-  g_type_class_add_private (klass, sizeof (BtSequencePrivate));
 
   gobject_class->set_property = bt_sequence_set_property;
   gobject_class->get_property = bt_sequence_get_property;

--- a/src/lib/core/settings.c
+++ b/src/lib/core/settings.c
@@ -114,7 +114,8 @@ struct _BtSettingsPrivate
   GSettings *org_freedesktop_gstreamer_defaults;
 };
 
-G_DEFINE_TYPE (BtSettings, bt_settings, G_TYPE_OBJECT);
+G_DEFINE_TYPE_WITH_CODE (BtSettings, bt_settings, G_TYPE_OBJECT, 
+    G_ADD_PRIVATE(BtSettings));
 
 //-- helper
 
@@ -861,16 +862,13 @@ static void
 bt_settings_init (BtSettings * self)
 {
   GST_DEBUG ("!!!! self=%p", self);
-  self->priv =
-      G_TYPE_INSTANCE_GET_PRIVATE (self, BT_TYPE_SETTINGS, BtSettingsPrivate);
+  self->priv = bt_settings_get_instance_private(self);
 }
 
 static void
 bt_settings_class_init (BtSettingsClass * const klass)
 {
   GObjectClass *const gobject_class = G_OBJECT_CLASS (klass);
-
-  g_type_class_add_private (klass, sizeof (BtSettingsPrivate));
 
   gobject_class->set_property = bt_settings_set_property;
   gobject_class->get_property = bt_settings_get_property;

--- a/src/lib/core/setup.c
+++ b/src/lib/core/setup.c
@@ -380,6 +380,7 @@ static void bt_setup_persistence_interface_init (gpointer const g_iface,
     gpointer const iface_data);
 
 G_DEFINE_TYPE_WITH_CODE (BtSetup, bt_setup, G_TYPE_OBJECT,
+    G_ADD_PRIVATE(BtSetup)
     G_IMPLEMENT_INTERFACE (BT_TYPE_PERSISTENCE,
         bt_setup_persistence_interface_init));
 
@@ -2227,8 +2228,7 @@ bt_setup_finalize (GObject * const object)
 static void
 bt_setup_init (BtSetup * self)
 {
-  self->priv =
-      G_TYPE_INSTANCE_GET_PRIVATE (self, BT_TYPE_SETUP, BtSetupPrivate);
+  self->priv = bt_setup_get_instance_private(self);
 
   self->priv->properties =
       g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_free);
@@ -2242,8 +2242,6 @@ static void
 bt_setup_class_init (BtSetupClass * const klass)
 {
   GObjectClass *const gobject_class = G_OBJECT_CLASS (klass);
-
-  g_type_class_add_private (klass, sizeof (BtSetupPrivate));
 
   gobject_class->set_property = bt_setup_set_property;
   gobject_class->get_property = bt_setup_get_property;

--- a/src/lib/core/sink-bin.c
+++ b/src/lib/core/sink-bin.c
@@ -199,7 +199,8 @@ static void on_audio_sink_child_added (GstBin * bin, GstElement * element,
 
 //-- the class
 
-G_DEFINE_TYPE (BtSinkBin, bt_sink_bin, GST_TYPE_BIN);
+G_DEFINE_TYPE_WITH_CODE (BtSinkBin, bt_sink_bin, GST_TYPE_BIN, 
+    G_ADD_PRIVATE(BtSinkBin));
 
 //-- enums
 
@@ -1285,8 +1286,7 @@ bt_sink_bin_finalize (GObject * const object)
 static void
 bt_sink_bin_init (BtSinkBin * self)
 {
-  self->priv =
-      G_TYPE_INSTANCE_GET_PRIVATE (self, BT_TYPE_SINK_BIN, BtSinkBinPrivate);
+  self->priv = bt_sink_bin_get_instance_private(self);
 
   GST_INFO ("!!!! self=%p", self);
 
@@ -1323,8 +1323,6 @@ bt_sink_bin_class_init (BtSinkBinClass * klass)
 {
   GObjectClass *const gobject_class = G_OBJECT_CLASS (klass);
   GstElementClass *const element_class = GST_ELEMENT_CLASS (klass);
-
-  g_type_class_add_private (klass, sizeof (BtSinkBinPrivate));
 
   gobject_class->set_property = bt_sink_bin_set_property;
   gobject_class->get_property = bt_sink_bin_get_property;

--- a/src/lib/core/song-info.c
+++ b/src/lib/core/song-info.c
@@ -125,6 +125,7 @@ static void bt_song_info_persistence_interface_init (gpointer const g_iface,
     gpointer const iface_data);
 
 G_DEFINE_TYPE_WITH_CODE (BtSongInfo, bt_song_info, G_TYPE_OBJECT,
+    G_ADD_PRIVATE(BtSongInfo)
     G_IMPLEMENT_INTERFACE (BT_TYPE_PERSISTENCE,
         bt_song_info_persistence_interface_init));
 
@@ -706,8 +707,7 @@ bt_song_info_init (BtSongInfo * self)
   time_t now = time (NULL);
   const gchar *user_name;
 
-  self->priv =
-      G_TYPE_INSTANCE_GET_PRIVATE (self, BT_TYPE_SONG_INFO, BtSongInfoPrivate);
+  self->priv = bt_song_info_get_instance_private(self);
   self->priv->taglist = gst_tag_list_new_empty ();
 
   user_name = g_get_real_name ();
@@ -743,8 +743,6 @@ static void
 bt_song_info_class_init (BtSongInfoClass * const klass)
 {
   GObjectClass *const gobject_class = G_OBJECT_CLASS (klass);
-
-  g_type_class_add_private (klass, sizeof (BtSongInfoPrivate));
 
   gobject_class->set_property = bt_song_info_set_property;
   gobject_class->get_property = bt_song_info_get_property;

--- a/src/lib/core/song-io-native-bzt.c
+++ b/src/lib/core/song-io-native-bzt.c
@@ -71,8 +71,9 @@ static GQuark error_domain = 0;
 
 //-- the class
 
-G_DEFINE_TYPE (BtSongIONativeBZT, bt_song_io_native_bzt,
-    BT_TYPE_SONG_IO_NATIVE);
+G_DEFINE_TYPE_WITH_CODE (BtSongIONativeBZT, bt_song_io_native_bzt,
+    BT_TYPE_SONG_IO_NATIVE,
+    G_ADD_PRIVATE(BtSongIONativeBZT));
 
 //-- public methods
 
@@ -458,9 +459,7 @@ bt_song_io_native_bzt_dispose (GObject * const object)
 static void
 bt_song_io_native_bzt_init (BtSongIONativeBZT * self)
 {
-  self->priv =
-      G_TYPE_INSTANCE_GET_PRIVATE (self, BT_TYPE_SONG_IO_NATIVE_BZT,
-      BtSongIONativeBZTPrivate);
+  self->priv = bt_song_io_native_bzt_get_instance_private(self);
 }
 
 static void
@@ -470,7 +469,6 @@ bt_song_io_native_bzt_class_init (BtSongIONativeBZTClass * const klass)
   BtSongIOClass *const btsongio_class = BT_SONG_IO_CLASS (klass);
 
   error_domain = g_type_qname (BT_TYPE_SONG_IO_NATIVE_BZT);
-  g_type_class_add_private (klass, sizeof (BtSongIONativeBZTPrivate));
 
   gobject_class->dispose = bt_song_io_native_bzt_dispose;
 

--- a/src/lib/core/song-io.c
+++ b/src/lib/core/song-io.c
@@ -73,7 +73,8 @@ static GList *plugins = NULL;
 
 //-- the class
 
-G_DEFINE_ABSTRACT_TYPE (BtSongIO, bt_song_io, G_TYPE_OBJECT);
+G_DEFINE_ABSTRACT_TYPE_WITH_CODE (BtSongIO, bt_song_io, G_TYPE_OBJECT,
+    G_ADD_PRIVATE(BtSongIO));
 
 //-- error codes
 
@@ -590,16 +591,13 @@ bt_song_io_finalize (GObject * const object)
 static void
 bt_song_io_init (BtSongIO * self)
 {
-  self->priv =
-      G_TYPE_INSTANCE_GET_PRIVATE (self, BT_TYPE_SONG_IO, BtSongIOPrivate);
+  self->priv = bt_song_io_get_instance_private(self);
 }
 
 static void
 bt_song_io_class_init (BtSongIOClass * const klass)
 {
   GObjectClass *const gobject_class = G_OBJECT_CLASS (klass);
-
-  g_type_class_add_private (klass, sizeof (BtSongIOPrivate));
 
   gobject_class->set_property = bt_song_io_set_property;
   gobject_class->get_property = bt_song_io_get_property;

--- a/src/lib/core/song.c
+++ b/src/lib/core/song.c
@@ -243,6 +243,7 @@ static void bt_song_persistence_interface_init (gpointer const g_iface,
 
 
 G_DEFINE_TYPE_WITH_CODE (BtSong, bt_song, G_TYPE_OBJECT,
+    G_ADD_PRIVATE(BtSong)
     G_IMPLEMENT_INTERFACE (BT_TYPE_PERSISTENCE,
         bt_song_persistence_interface_init));
 
@@ -1771,7 +1772,7 @@ bt_song_init (BtSong * self)
 {
   GstClockTime s, e;
 
-  self->priv = G_TYPE_INSTANCE_GET_PRIVATE (self, BT_TYPE_SONG, BtSongPrivate);
+  self->priv = bt_song_get_instance_private(self);
 
   self->priv->position_query = gst_query_new_position (GST_FORMAT_TIME);
   self->priv->play_rate = 1.0;
@@ -1787,8 +1788,6 @@ static void
 bt_song_class_init (BtSongClass * const klass)
 {
   GObjectClass *const gobject_class = G_OBJECT_CLASS (klass);
-
-  g_type_class_add_private (klass, sizeof (BtSongPrivate));
 
   gobject_class->constructed = bt_song_constructed;
   gobject_class->set_property = bt_song_set_property;

--- a/src/lib/core/songio/bsl/song-io-buzz.c
+++ b/src/lib/core/songio/bsl/song-io-buzz.c
@@ -61,7 +61,8 @@ struct _BtSongIOBuzzPrivate
 
 //-- the class
 
-G_DEFINE_TYPE (BtSongIOBuzz, bt_song_io_buzz, BT_TYPE_SONG_IO);
+G_DEFINE_TYPE_WITH_CODE (BtSongIOBuzz, bt_song_io_buzz, BT_TYPE_SONG_IO, 
+    G_ADD_PRIVATE(BtSongIOBuzz));
 
 
 typedef enum
@@ -2457,9 +2458,7 @@ bt_song_io_buzz_finalize (GObject * object)
 static void
 bt_song_io_buzz_init (BtSongIOBuzz * self)
 {
-  self->priv =
-      G_TYPE_INSTANCE_GET_PRIVATE (self, BT_TYPE_SONG_IO_BUZZ,
-      BtSongIOBuzzPrivate);
+  self->priv = bt_song_io_buzz_get_instance_private(self);
 }
 
 static void
@@ -2467,8 +2466,6 @@ bt_song_io_buzz_class_init (BtSongIOBuzzClass * klass)
 {
   GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
   BtSongIOClass *base_class = BT_SONG_IO_CLASS (klass);
-
-  g_type_class_add_private (klass, sizeof (BtSongIOBuzzPrivate));
 
   gobject_class->finalize = bt_song_io_buzz_finalize;
 

--- a/src/lib/core/value-group.c
+++ b/src/lib/core/value-group.c
@@ -72,7 +72,8 @@ static guint signals[LAST_SIGNAL] = { 0, };
 
 //-- the class
 
-G_DEFINE_TYPE (BtValueGroup, bt_value_group, G_TYPE_OBJECT);
+G_DEFINE_TYPE_WITH_CODE (BtValueGroup, bt_value_group, G_TYPE_OBJECT, 
+    G_ADD_PRIVATE(BtValueGroup));
 
 //-- macros
 
@@ -1376,9 +1377,7 @@ static void
 bt_value_group_init (BtValueGroup * self)
 {
   GST_DEBUG ("!!!! self=%p", self);
-  self->priv =
-      G_TYPE_INSTANCE_GET_PRIVATE (self, BT_TYPE_VALUE_GROUP,
-      BtValueGroupPrivate);
+  self->priv = bt_value_group_get_instance_private(self);
 }
 
 static void
@@ -1387,7 +1386,6 @@ bt_value_group_class_init (BtValueGroupClass * const klass)
   GObjectClass *const gobject_class = G_OBJECT_CLASS (klass);
 
   GST_DEBUG ("!!!!");
-  g_type_class_add_private (klass, sizeof (BtValueGroupPrivate));
 
   gobject_class->constructed = bt_value_group_constructed;
   gobject_class->set_property = bt_value_group_set_property;

--- a/src/lib/core/wave.c
+++ b/src/lib/core/wave.c
@@ -111,6 +111,7 @@ static void bt_wave_persistence_interface_init (gpointer const g_iface,
     gpointer const iface_data);
 
 G_DEFINE_TYPE_WITH_CODE (BtWave, bt_wave, G_TYPE_OBJECT,
+    G_ADD_PRIVATE(BtWave)
     G_IMPLEMENT_INTERFACE (BT_TYPE_PERSISTENCE,
         bt_wave_persistence_interface_init));
 
@@ -989,7 +990,7 @@ bt_wave_finalize (GObject * const object)
 static void
 bt_wave_init (BtWave * self)
 {
-  self->priv = G_TYPE_INSTANCE_GET_PRIVATE (self, BT_TYPE_WAVE, BtWavePrivate);
+  self->priv = bt_wave_get_instance_private(self);
   self->priv->volume = 1.0;
   self->priv->fd = -1;
   self->priv->ext_fd = -1;
@@ -1001,7 +1002,6 @@ bt_wave_class_init (BtWaveClass * const klass)
   GObjectClass *const gobject_class = G_OBJECT_CLASS (klass);
 
   error_domain = g_type_qname (BT_TYPE_WAVE);
-  g_type_class_add_private (klass, sizeof (BtWavePrivate));
 
   gobject_class->constructed = bt_wave_constructed;
   gobject_class->set_property = bt_wave_set_property;

--- a/src/lib/core/wavelevel.c
+++ b/src/lib/core/wavelevel.c
@@ -71,6 +71,7 @@ static void bt_wavelevel_persistence_interface_init (gpointer const g_iface,
     gpointer const iface_data);
 
 G_DEFINE_TYPE_WITH_CODE (BtWavelevel, bt_wavelevel, G_TYPE_OBJECT,
+    G_ADD_PRIVATE(BtWavelevel)
     G_IMPLEMENT_INTERFACE (BT_TYPE_PERSISTENCE,
         bt_wavelevel_persistence_interface_init));
 
@@ -348,8 +349,7 @@ bt_wavelevel_finalize (GObject * const object)
 static void
 bt_wavelevel_init (BtWavelevel * self)
 {
-  self->priv =
-      G_TYPE_INSTANCE_GET_PRIVATE (self, BT_TYPE_WAVELEVEL, BtWavelevelPrivate);
+  self->priv = bt_wavelevel_get_instance_private(self);
   self->priv->root_note = BT_WAVELEVEL_DEFAULT_ROOT_NOTE;
 }
 
@@ -359,8 +359,6 @@ static void
 bt_wavelevel_class_init (BtWavelevelClass * const klass)
 {
   GObjectClass *const gobject_class = G_OBJECT_CLASS (klass);
-
-  g_type_class_add_private (klass, sizeof (BtWavelevelPrivate));
 
   gobject_class->constructed = bt_wavelevel_constructed;
   gobject_class->set_property = bt_wavelevel_set_property;

--- a/src/lib/core/wavetable.c
+++ b/src/lib/core/wavetable.c
@@ -79,6 +79,7 @@ static void bt_wavetable_persistence_interface_init (gpointer const g_iface,
     gpointer const iface_data);
 
 G_DEFINE_TYPE_WITH_CODE (BtWavetable, bt_wavetable, G_TYPE_OBJECT,
+    G_ADD_PRIVATE(BtWavetable)
     G_IMPLEMENT_INTERFACE (BT_TYPE_PERSISTENCE,
         bt_wavetable_persistence_interface_init));
 
@@ -417,16 +418,13 @@ bt_wavetable_finalize (GObject * const object)
 static void
 bt_wavetable_init (BtWavetable * self)
 {
-  self->priv =
-      G_TYPE_INSTANCE_GET_PRIVATE (self, BT_TYPE_WAVETABLE, BtWavetablePrivate);
+  self->priv = bt_wavetable_get_instance_private(self);
 }
 
 static void
 bt_wavetable_class_init (BtWavetableClass * const klass)
 {
   GObjectClass *const gobject_class = G_OBJECT_CLASS (klass);
-
-  g_type_class_add_private (klass, sizeof (BtWavetablePrivate));
 
   gobject_class->set_property = bt_wavetable_set_property;
   gobject_class->get_property = bt_wavetable_get_property;

--- a/src/lib/core/wire.c
+++ b/src/lib/core/wire.c
@@ -142,6 +142,7 @@ static void bt_wire_persistence_interface_init (gpointer const g_iface,
     gpointer const iface_data);
 
 G_DEFINE_TYPE_WITH_CODE (BtWire, bt_wire, GST_TYPE_BIN,
+    G_ADD_PRIVATE(BtWire)
     G_IMPLEMENT_INTERFACE (BT_TYPE_PERSISTENCE,
         bt_wire_persistence_interface_init));
 
@@ -1467,7 +1468,7 @@ bt_wire_finalize (GObject * const object)
 static void
 bt_wire_init (BtWire * self)
 {
-  self->priv = G_TYPE_INSTANCE_GET_PRIVATE (self, BT_TYPE_WIRE, BtWirePrivate);
+  self->priv = bt_wire_get_instance_private(self);
   self->priv->num_params = 1;
   self->priv->properties =
       g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_free);
@@ -1489,7 +1490,6 @@ bt_wire_class_init (BtWireClass * const klass)
   GstElementClass *const gstelement_klass = GST_ELEMENT_CLASS (klass);
 
   error_domain = g_type_qname (BT_TYPE_WIRE);
-  g_type_class_add_private (klass, sizeof (BtWirePrivate));
 
   gobject_class->constructed = bt_wire_constructed;
   gobject_class->set_property = bt_wire_set_property;

--- a/src/lib/gst/audiosynth.c
+++ b/src/lib/gst/audiosynth.c
@@ -424,7 +424,7 @@ gstbt_audio_synth_create (GstBaseSrc * basesrc, guint64 offset,
   src->n_samples = n_samples;
 
   if (gst_buffer_map (buf, &info, GST_MAP_WRITE)) {
-    if (!klass->process (src, buf, &info)) {
+    if (klass->process && !klass->process (src, buf, &info)) {
       memset (info.data, 0, info.size);
       GST_BUFFER_FLAG_SET (buf, GST_BUFFER_FLAG_GAP);
     }

--- a/src/lib/ic/abs-range-control.c
+++ b/src/lib/ic/abs-range-control.c
@@ -45,7 +45,8 @@ struct _BtIcAbsRangeControlPrivate
 
 //-- the class
 
-G_DEFINE_TYPE (BtIcAbsRangeControl, btic_abs_range_control, BTIC_TYPE_CONTROL);
+G_DEFINE_TYPE_WITH_CODE (BtIcAbsRangeControl, btic_abs_range_control, BTIC_TYPE_CONTROL,
+    G_ADD_PRIVATE(BtIcAbsRangeControl));
 
 //-- helper
 
@@ -161,17 +162,13 @@ btic_abs_range_control_dispose (GObject * const object)
 static void
 btic_abs_range_control_init (BtIcAbsRangeControl * self)
 {
-  self->priv =
-      G_TYPE_INSTANCE_GET_PRIVATE (self, BTIC_TYPE_ABS_RANGE_CONTROL,
-      BtIcAbsRangeControlPrivate);
+  self->priv = btic_abs_range_control_get_instance_private(self);
 }
 
 static void
 btic_abs_range_control_class_init (BtIcAbsRangeControlClass * const klass)
 {
   GObjectClass *const gobject_class = G_OBJECT_CLASS (klass);
-
-  g_type_class_add_private (klass, sizeof (BtIcAbsRangeControlPrivate));
 
   gobject_class->set_property = btic_abs_range_control_set_property;
   gobject_class->get_property = btic_abs_range_control_get_property;

--- a/src/lib/ic/aseq-device.c
+++ b/src/lib/ic/aseq-device.c
@@ -57,7 +57,8 @@ static void btic_aseq_device_interface_init (gpointer const g_iface,
     gpointer const iface_data);
 
 G_DEFINE_TYPE_WITH_CODE (BtIcASeqDevice, btic_aseq_device, BTIC_TYPE_DEVICE,
-    G_IMPLEMENT_INTERFACE (BTIC_TYPE_LEARN, btic_aseq_device_interface_init));
+    G_ADD_PRIVATE(BtIcASeqDevice)
+	G_IMPLEMENT_INTERFACE (BTIC_TYPE_LEARN, btic_aseq_device_interface_init));
 
 //-- defines
 
@@ -446,9 +447,7 @@ btic_aseq_device_finalize (GObject * const object)
 static void
 btic_aseq_device_init (BtIcASeqDevice * self)
 {
-  self->priv =
-      G_TYPE_INSTANCE_GET_PRIVATE (self, BTIC_TYPE_ASEQ_DEVICE,
-      BtIcASeqDevicePrivate);
+  self->priv = btic_aseq_device_get_instance_private(self);
   self->priv->src_port = -1;
 }
 
@@ -458,8 +457,6 @@ btic_aseq_device_class_init (BtIcASeqDeviceClass * const klass)
   GObjectClass *const gobject_class = G_OBJECT_CLASS (klass);
   BtIcDeviceClass *const bticdevice_class = BTIC_DEVICE_CLASS (klass);
   gint err;
-
-  g_type_class_add_private (klass, sizeof (BtIcASeqDevicePrivate));
 
   gobject_class->constructed = btic_aseq_device_constructed;
   gobject_class->set_property = btic_aseq_device_set_property;

--- a/src/lib/ic/aseq-discoverer.c
+++ b/src/lib/ic/aseq-discoverer.c
@@ -40,7 +40,8 @@ struct _BtIcASeqDiscovererPrivate
 
 //-- the class
 
-G_DEFINE_TYPE (BtIcASeqDiscoverer, btic_aseq_discoverer, G_TYPE_OBJECT);
+G_DEFINE_TYPE_WITH_CODE (BtIcASeqDiscoverer, btic_aseq_discoverer, G_TYPE_OBJECT,
+						 G_ADD_PRIVATE(BtIcASeqDiscoverer));
 
 //-- helper
 
@@ -365,17 +366,13 @@ done:
 static void
 btic_aseq_discoverer_init (BtIcASeqDiscoverer * self)
 {
-  self->priv =
-      G_TYPE_INSTANCE_GET_PRIVATE (self, BTIC_TYPE_ASEQ_DISCOVERER,
-      BtIcASeqDiscovererPrivate);
+  self->priv = btic_aseq_discoverer_get_instance_private(self);
 }
 
 static void
 btic_aseq_discoverer_class_init (BtIcASeqDiscovererClass * const klass)
 {
   GObjectClass *const gobject_class = G_OBJECT_CLASS (klass);
-
-  g_type_class_add_private (klass, sizeof (BtIcASeqDiscovererPrivate));
 
   gobject_class->constructor = btic_aseq_discoverer_constructor;
   gobject_class->finalize = btic_aseq_discoverer_finalize;

--- a/src/lib/ic/control.c
+++ b/src/lib/ic/control.c
@@ -78,7 +78,7 @@ struct _BtIcControlPrivate
 
 //-- the class
 
-G_DEFINE_ABSTRACT_TYPE (BtIcControl, btic_control, G_TYPE_OBJECT);
+G_DEFINE_ABSTRACT_TYPE_WITH_CODE (BtIcControl, btic_control, G_TYPE_OBJECT, G_ADD_PRIVATE(BtIcControl));
 
 //-- helper
 
@@ -193,16 +193,13 @@ btic_control_finalize (GObject * const object)
 static void
 btic_control_init (BtIcControl * self)
 {
-  self->priv =
-      G_TYPE_INSTANCE_GET_PRIVATE (self, BTIC_TYPE_CONTROL, BtIcControlPrivate);
+  self->priv = btic_control_get_instance_private(self);
 }
 
 static void
 btic_control_class_init (BtIcControlClass * const klass)
 {
   GObjectClass *const gobject_class = G_OBJECT_CLASS (klass);
-
-  g_type_class_add_private (klass, sizeof (BtIcControlPrivate));
 
   gobject_class->set_property = btic_control_set_property;
   gobject_class->get_property = btic_control_get_property;

--- a/src/lib/ic/device.c
+++ b/src/lib/ic/device.c
@@ -60,7 +60,7 @@ struct _BtIcDevicePrivate
 
 //-- the class
 
-G_DEFINE_ABSTRACT_TYPE (BtIcDevice, btic_device, G_TYPE_OBJECT);
+G_DEFINE_ABSTRACT_TYPE_WITH_CODE (BtIcDevice, btic_device, G_TYPE_OBJECT, G_ADD_PRIVATE(BtIcDevice));
 
 //-- helper
 
@@ -353,8 +353,7 @@ btic_device_finalize (GObject * const object)
 static void
 btic_device_init (BtIcDevice * self)
 {
-  self->priv =
-      G_TYPE_INSTANCE_GET_PRIVATE (self, BTIC_TYPE_DEVICE, BtIcDevicePrivate);
+  self->priv = btic_device_get_instance_private(self);
 
   self->priv->controls_by_id =
       g_hash_table_new_full (NULL, NULL, NULL, (GDestroyNotify) g_object_unref);
@@ -364,8 +363,6 @@ static void
 btic_device_class_init (BtIcDeviceClass * const klass)
 {
   GObjectClass *const gobject_class = G_OBJECT_CLASS (klass);
-
-  g_type_class_add_private (klass, sizeof (BtIcDevicePrivate));
 
   gobject_class->set_property = btic_device_set_property;
   gobject_class->get_property = btic_device_get_property;

--- a/src/lib/ic/gudev-discoverer.c
+++ b/src/lib/ic/gudev-discoverer.c
@@ -39,7 +39,8 @@ struct _BtIcGudevDiscovererPrivate
 
 //-- the class
 
-G_DEFINE_TYPE (BtIcGudevDiscoverer, btic_gudev_discoverer, G_TYPE_OBJECT);
+G_DEFINE_TYPE_WITH_CODE (BtIcGudevDiscoverer, btic_gudev_discoverer, G_TYPE_OBJECT,
+						 G_ADD_PRIVATE(BtIcGudevDiscoverer));
 
 //-- helper
 
@@ -303,17 +304,13 @@ done:
 static void
 btic_gudev_discoverer_init (BtIcGudevDiscoverer * self)
 {
-  self->priv =
-      G_TYPE_INSTANCE_GET_PRIVATE (self, BTIC_TYPE_GUDEV_DISCOVERER,
-      BtIcGudevDiscovererPrivate);
+  self->priv = btic_gudev_discoverer_get_instance_private(self);
 }
 
 static void
 btic_gudev_discoverer_class_init (BtIcGudevDiscovererClass * const klass)
 {
   GObjectClass *const gobject_class = G_OBJECT_CLASS (klass);
-
-  g_type_class_add_private (klass, sizeof (BtIcGudevDiscovererPrivate));
 
   gobject_class->constructor = btic_gudev_discoverer_constructor;
   gobject_class->dispose = btic_gudev_discoverer_dispose;

--- a/src/lib/ic/input-device.c
+++ b/src/lib/ic/input-device.c
@@ -61,7 +61,7 @@ struct _BtIcInputDevicePrivate
 
 //-- the class
 
-G_DEFINE_TYPE (BtIcInputDevice, btic_input_device, BTIC_TYPE_DEVICE);
+G_DEFINE_TYPE_WITH_CODE (BtIcInputDevice, btic_input_device, BTIC_TYPE_DEVICE, G_ADD_PRIVATE(BtIcInputDevice));
 
 //-- helper
 #define test_bit(bit, array)    (array[bit>>3] & (1<<(bit&0x7)))
@@ -633,9 +633,7 @@ btic_input_device_finalize (GObject * const object)
 static void
 btic_input_device_init (BtIcInputDevice * self)
 {
-  self->priv =
-      G_TYPE_INSTANCE_GET_PRIVATE (self, BTIC_TYPE_INPUT_DEVICE,
-      BtIcInputDevicePrivate);
+  self->priv = btic_input_device_get_instance_private(self);
 }
 
 static void
@@ -643,8 +641,6 @@ btic_input_device_class_init (BtIcInputDeviceClass * const klass)
 {
   GObjectClass *const gobject_class = G_OBJECT_CLASS (klass);
   BtIcDeviceClass *const bticdevice_class = BTIC_DEVICE_CLASS (klass);
-
-  g_type_class_add_private (klass, sizeof (BtIcInputDevicePrivate));
 
   gobject_class->set_property = btic_input_device_set_property;
   gobject_class->get_property = btic_input_device_get_property;

--- a/src/lib/ic/midi-device.c
+++ b/src/lib/ic/midi-device.c
@@ -70,7 +70,8 @@ static void btic_midi_device_interface_init (gpointer const g_iface,
     gpointer const iface_data);
 
 G_DEFINE_TYPE_WITH_CODE (BtIcMidiDevice, btic_midi_device, BTIC_TYPE_DEVICE,
-    G_IMPLEMENT_INTERFACE (BTIC_TYPE_LEARN, btic_midi_device_interface_init));
+						 G_IMPLEMENT_INTERFACE (BTIC_TYPE_LEARN, btic_midi_device_interface_init)
+						 G_ADD_PRIVATE(BtIcMidiDevice));
 
 //-- defines
 
@@ -569,9 +570,7 @@ btic_midi_device_finalize (GObject * const object)
 static void
 btic_midi_device_init (BtIcMidiDevice * self)
 {
-  self->priv =
-      G_TYPE_INSTANCE_GET_PRIVATE (self, BTIC_TYPE_MIDI_DEVICE,
-      BtIcMidiDevicePrivate);
+  self->priv = btic_midi_device_get_instance_private(self);
 }
 
 static void
@@ -579,8 +578,6 @@ btic_midi_device_class_init (BtIcMidiDeviceClass * const klass)
 {
   GObjectClass *const gobject_class = G_OBJECT_CLASS (klass);
   BtIcDeviceClass *const bticdevice_class = BTIC_DEVICE_CLASS (klass);
-
-  g_type_class_add_private (klass, sizeof (BtIcMidiDevicePrivate));
 
   gobject_class->constructed = btic_midi_device_constructed;
   gobject_class->set_property = btic_midi_device_set_property;

--- a/src/lib/ic/registry.c
+++ b/src/lib/ic/registry.c
@@ -51,7 +51,7 @@ static BtIcRegistry *singleton = NULL;
 
 //-- the class
 
-G_DEFINE_TYPE (BtIcRegistry, btic_registry, G_TYPE_OBJECT);
+G_DEFINE_TYPE_WITH_CODE (BtIcRegistry, btic_registry, G_TYPE_OBJECT, G_ADD_PRIVATE(BtIcRegistry));
 
 //-- helper
 
@@ -283,17 +283,13 @@ btic_registry_constructor (GType type, guint n_construct_params,
 static void
 btic_registry_init (BtIcRegistry * self)
 {
-  self->priv =
-      G_TYPE_INSTANCE_GET_PRIVATE (self, BTIC_TYPE_REGISTRY,
-      BtIcRegistryPrivate);
+  self->priv = btic_registry_get_instance_private(self);
 }
 
 static void
 btic_registry_class_init (BtIcRegistryClass * const klass)
 {
   GObjectClass *const gobject_class = G_OBJECT_CLASS (klass);
-
-  g_type_class_add_private (klass, sizeof (BtIcRegistryPrivate));
 
   gobject_class->constructor = btic_registry_constructor;
   gobject_class->get_property = btic_registry_get_property;

--- a/src/lib/ic/trigger-control.c
+++ b/src/lib/ic/trigger-control.c
@@ -42,7 +42,8 @@ struct _BtIcTriggerControlPrivate
 
 //-- the class
 
-G_DEFINE_TYPE (BtIcTriggerControl, btic_trigger_control, BTIC_TYPE_CONTROL);
+G_DEFINE_TYPE_WITH_CODE (BtIcTriggerControl, btic_trigger_control, BTIC_TYPE_CONTROL,
+						 G_ADD_PRIVATE(BtIcTriggerControl));
 
 //-- helper
 
@@ -136,17 +137,13 @@ btic_trigger_control_dispose (GObject * const object)
 static void
 btic_trigger_control_init (BtIcTriggerControl * self)
 {
-  self->priv =
-      G_TYPE_INSTANCE_GET_PRIVATE (self, BTIC_TYPE_TRIGGER_CONTROL,
-      BtIcTriggerControlPrivate);
+  self->priv = btic_trigger_control_get_instance_private(self);
 }
 
 static void
 btic_trigger_control_class_init (BtIcTriggerControlClass * const klass)
 {
   GObjectClass *const gobject_class = G_OBJECT_CLASS (klass);
-
-  g_type_class_add_private (klass, sizeof (BtIcTriggerControlPrivate));
 
   gobject_class->set_property = btic_trigger_control_set_property;
   gobject_class->get_property = btic_trigger_control_get_property;

--- a/src/ui/cmd/cmd-application.c
+++ b/src/ui/cmd/cmd-application.c
@@ -68,7 +68,8 @@ static gboolean is_playing = FALSE;
 
 //-- the class
 
-G_DEFINE_TYPE (BtCmdApplication, bt_cmd_application, BT_TYPE_APPLICATION);
+G_DEFINE_TYPE_WITH_CODE (BtCmdApplication, bt_cmd_application, BT_TYPE_APPLICATION, 
+    G_ADD_PRIVATE(BtCmdApplication));
 
 //-- helper methods
 
@@ -709,9 +710,7 @@ static void
 bt_cmd_application_init (BtCmdApplication * self)
 {
   GST_DEBUG ("!!!! self=%p", self);
-  self->priv =
-      G_TYPE_INSTANCE_GET_PRIVATE (self, BT_TYPE_CMD_APPLICATION,
-      BtCmdApplicationPrivate);
+  self->priv = bt_cmd_application_get_instance_private(self);
 
   self->priv->loop = g_main_loop_new (NULL, FALSE);
 #if THREADED_MAIN
@@ -725,8 +724,6 @@ bt_cmd_application_class_init (BtCmdApplicationClass * klass)
   GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
 
   GST_DEBUG ("!!!!");
-  g_type_class_add_private (klass, sizeof (BtCmdApplicationPrivate));
-
   gobject_class->set_property = bt_cmd_application_set_property;
   gobject_class->dispose = bt_cmd_application_dispose;
   gobject_class->finalize = bt_cmd_application_finalize;

--- a/src/ui/edit/about-dialog.c
+++ b/src/ui/edit/about-dialog.c
@@ -37,7 +37,8 @@ struct _BtAboutDialogPrivate
 
 //-- the class
 
-G_DEFINE_TYPE (BtAboutDialog, bt_about_dialog, GTK_TYPE_ABOUT_DIALOG);
+G_DEFINE_TYPE_WITH_CODE (BtAboutDialog, bt_about_dialog, GTK_TYPE_ABOUT_DIALOG, 
+    G_ADD_PRIVATE(BtAboutDialog));
 
 //-- event handler
 
@@ -173,9 +174,7 @@ bt_about_dialog_dispose (GObject * object)
 static void
 bt_about_dialog_init (BtAboutDialog * self)
 {
-  self->priv =
-      G_TYPE_INSTANCE_GET_PRIVATE (self, BT_TYPE_ABOUT_DIALOG,
-      BtAboutDialogPrivate);
+  self->priv = bt_about_dialog_get_instance_private(self);
   GST_DEBUG ("!!!! self=%p", self);
   self->priv->app = bt_edit_application_new ();
 }
@@ -184,8 +183,6 @@ static void
 bt_about_dialog_class_init (BtAboutDialogClass * klass)
 {
   GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
-
-  g_type_class_add_private (klass, sizeof (BtAboutDialogPrivate));
 
   gobject_class->dispose = bt_about_dialog_dispose;
 }

--- a/src/ui/edit/change-log.c
+++ b/src/ui/edit/change-log.c
@@ -250,7 +250,8 @@ static BtChangeLog *singleton = NULL;
 
 //-- the class
 
-G_DEFINE_TYPE (BtChangeLog, bt_change_log, G_TYPE_OBJECT);
+G_DEFINE_TYPE_WITH_CODE (BtChangeLog, bt_change_log, G_TYPE_OBJECT, 
+    G_ADD_PRIVATE(BtChangeLog));
 
 //-- helper
 
@@ -1192,9 +1193,7 @@ bt_change_log_get_property (GObject * object, guint property_id, GValue * value,
 static void
 bt_change_log_init (BtChangeLog * self)
 {
-  self->priv =
-      G_TYPE_INSTANCE_GET_PRIVATE (self, BT_TYPE_CHANGE_LOG,
-      BtChangeLogPrivate);
+  self->priv = bt_change_log_get_instance_private(self);
   /* this is created from the app, we need to avoid a ref-cycle */
   self->priv->app = bt_edit_application_new ();
   g_object_try_weak_ref (self->priv->app);
@@ -1231,8 +1230,6 @@ static void
 bt_change_log_class_init (BtChangeLogClass * klass)
 {
   GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
-
-  g_type_class_add_private (klass, sizeof (BtChangeLogPrivate));
 
   gobject_class->get_property = bt_change_log_get_property;
   gobject_class->constructor = bt_change_log_constructor;

--- a/src/ui/edit/crash-recover-dialog.c
+++ b/src/ui/edit/crash-recover-dialog.c
@@ -79,7 +79,8 @@ struct _BtCrashRecoverDialogPrivate
 
 //-- the class
 
-G_DEFINE_TYPE (BtCrashRecoverDialog, bt_crash_recover_dialog, GTK_TYPE_DIALOG);
+G_DEFINE_TYPE_WITH_CODE (BtCrashRecoverDialog, bt_crash_recover_dialog, GTK_TYPE_DIALOG, 
+    G_ADD_PRIVATE(BtCrashRecoverDialog));
 
 //-- helper
 
@@ -374,9 +375,7 @@ bt_crash_recover_dialog_dispose (GObject * object)
 static void
 bt_crash_recover_dialog_init (BtCrashRecoverDialog * self)
 {
-  self->priv =
-      G_TYPE_INSTANCE_GET_PRIVATE (self, BT_TYPE_CRASH_RECOVER_DIALOG,
-      BtCrashRecoverDialogPrivate);
+  self->priv = bt_crash_recover_dialog_get_instance_private(self);
   GST_DEBUG ("!!!! self=%p", self);
   self->priv->app = bt_edit_application_new ();
 }
@@ -385,8 +384,6 @@ static void
 bt_crash_recover_dialog_class_init (BtCrashRecoverDialogClass * klass)
 {
   GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
-
-  g_type_class_add_private (klass, sizeof (BtCrashRecoverDialogPrivate));
 
   gobject_class->set_property = bt_crash_recover_dialog_set_property;
   gobject_class->dispose = bt_crash_recover_dialog_dispose;

--- a/src/ui/edit/edit-application.c
+++ b/src/ui/edit/edit-application.c
@@ -94,7 +94,8 @@ static BtEditApplication *singleton = NULL;
 
 //-- the class
 
-G_DEFINE_TYPE (BtEditApplication, bt_edit_application, BT_TYPE_APPLICATION);
+G_DEFINE_TYPE_WITH_CODE (BtEditApplication, bt_edit_application, BT_TYPE_APPLICATION, 
+    G_ADD_PRIVATE(BtEditApplication));
 
 //-- event handler
 
@@ -987,17 +988,13 @@ bt_edit_application_dispose (GObject * object)
 static void
 bt_edit_application_init (BtEditApplication * self)
 {
-  self->priv =
-      G_TYPE_INSTANCE_GET_PRIVATE (self, BT_TYPE_EDIT_APPLICATION,
-      BtEditApplicationPrivate);
+  self->priv = bt_edit_application_get_instance_private(self);
 }
 
 static void
 bt_edit_application_class_init (BtEditApplicationClass * klass)
 {
   GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
-
-  g_type_class_add_private (klass, sizeof (BtEditApplicationPrivate));
 
   gobject_class->constructor = bt_edit_application_constructor;
   gobject_class->set_property = bt_edit_application_set_property;

--- a/src/ui/edit/gtkscrolledsyncwindow.c
+++ b/src/ui/edit/gtkscrolledsyncwindow.c
@@ -168,7 +168,8 @@ static void gtk_scrolled_sync_window_cancel_deceleration (GtkScrolledSyncWindow
 
 static guint signals[LAST_SIGNAL] = { 0 };
 
-G_DEFINE_TYPE (GtkScrolledSyncWindow, gtk_scrolled_sync_window, GTK_TYPE_BIN)
+G_DEFINE_TYPE_WITH_CODE (GtkScrolledSyncWindow, gtk_scrolled_sync_window, GTK_TYPE_BIN, 
+    G_ADD_PRIVATE(GtkScrolledSyncWindow));
 
      static void
          add_scroll_binding (GtkBindingSet * binding_set,
@@ -202,8 +203,6 @@ gtk_scrolled_sync_window_class_init (GtkScrolledSyncWindowClass * klass)
   GtkWidgetClass *widget_class = (GtkWidgetClass *) klass;
   GtkContainerClass *container_class = (GtkContainerClass *) klass;
   GtkBindingSet *binding_set;
-
-  g_type_class_add_private (klass, sizeof (GtkScrolledSyncWindowPrivate));
 
   gobject_class->set_property = gtk_scrolled_sync_window_set_property;
   gobject_class->get_property = gtk_scrolled_sync_window_get_property;
@@ -345,9 +344,7 @@ gtk_scrolled_sync_window_init (GtkScrolledSyncWindow * self)
 {
   GtkScrolledSyncWindowPrivate *priv;
 
-  self->priv = priv =
-      G_TYPE_INSTANCE_GET_PRIVATE (self,
-      GTK_TYPE_SCROLLED_SYNC_WINDOW, GtkScrolledSyncWindowPrivate);
+  self->priv = priv = gtk_scrolled_sync_window_get_instance_private(self);
 
   gtk_widget_set_has_window (GTK_WIDGET (self), FALSE);
   gtk_widget_set_can_focus (GTK_WIDGET (self), TRUE);

--- a/src/ui/edit/interaction-controller-menu.c
+++ b/src/ui/edit/interaction-controller-menu.c
@@ -81,8 +81,9 @@ extern GQuark bt_machine_property_name;
 
 //-- the class
 
-G_DEFINE_TYPE (BtInteractionControllerMenu, bt_interaction_controller_menu,
-    GTK_TYPE_MENU);
+G_DEFINE_TYPE_WITH_CODE (BtInteractionControllerMenu, bt_interaction_controller_menu,
+    GTK_TYPE_MENU, 
+    G_ADD_PRIVATE(BtInteractionControllerMenu));
 
 //-- prototypes
 
@@ -571,9 +572,7 @@ bt_interaction_controller_menu_finalize (GObject * object)
 static void
 bt_interaction_controller_menu_init (BtInteractionControllerMenu * self)
 {
-  self->priv =
-      G_TYPE_INSTANCE_GET_PRIVATE (self, BT_TYPE_INTERACTION_CONTROLLER_MENU,
-      BtInteractionControllerMenuPrivate);
+  self->priv = bt_interaction_controller_menu_get_instance_private(self);
   GST_DEBUG ("!!!! self=%p", self);
   self->priv->app = bt_edit_application_new ();
   self->priv->menuitem_to_control = g_hash_table_new (NULL, NULL);
@@ -586,8 +585,6 @@ bt_interaction_controller_menu_class_init (BtInteractionControllerMenuClass *
     klass)
 {
   GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
-
-  g_type_class_add_private (klass, sizeof (BtInteractionControllerMenuPrivate));
 
   gobject_class->set_property = bt_interaction_controller_menu_set_property;
   gobject_class->get_property = bt_interaction_controller_menu_get_property;

--- a/src/ui/edit/machine-canvas-item.c
+++ b/src/ui/edit/machine-canvas-item.c
@@ -159,7 +159,8 @@ static GQuark machine_canvas_item_quark = 0;
 
 //-- the class
 
-G_DEFINE_TYPE (BtMachineCanvasItem, bt_machine_canvas_item, CLUTTER_TYPE_ACTOR);
+G_DEFINE_TYPE_WITH_CODE (BtMachineCanvasItem, bt_machine_canvas_item, CLUTTER_TYPE_ACTOR, 
+    G_ADD_PRIVATE(BtMachineCanvasItem));
 
 
 //-- prototypes
@@ -1544,9 +1545,7 @@ bt_machine_canvas_item_init (BtMachineCanvasItem * self)
   GstBin *bin;
   GstBus *bus;
 
-  self->priv =
-      G_TYPE_INSTANCE_GET_PRIVATE (self, BT_TYPE_MACHINE_CANVAS_ITEM,
-      BtMachineCanvasItemPrivate);
+  self->priv = bt_machine_canvas_item_get_instance_private(self);
   GST_DEBUG ("!!!! self=%p", self);
   self->priv->app = bt_edit_application_new ();
 
@@ -1583,8 +1582,6 @@ bt_machine_canvas_item_class_init (BtMachineCanvasItemClass * klass)
   bus_msg_level_quark = g_quark_from_static_string ("level");
   machine_canvas_item_quark =
       g_quark_from_static_string ("machine-canvas-item");
-
-  g_type_class_add_private (klass, sizeof (BtMachineCanvasItemPrivate));
 
   gobject_class->constructed = bt_machine_canvas_item_constructed;
   gobject_class->set_property = bt_machine_canvas_item_set_property;

--- a/src/ui/edit/machine-list-model.c
+++ b/src/ui/edit/machine-list-model.c
@@ -49,7 +49,9 @@ static void bt_machine_list_model_tree_model_init (gpointer const g_iface,
     gpointer const iface_data);
 
 G_DEFINE_TYPE_WITH_CODE (BtMachineListModel, bt_machine_list_model,
-    G_TYPE_OBJECT, G_IMPLEMENT_INTERFACE (GTK_TYPE_TREE_MODEL,
+    G_TYPE_OBJECT,
+    G_ADD_PRIVATE(BtMachineListModel)
+    G_IMPLEMENT_INTERFACE (GTK_TYPE_TREE_MODEL,
         bt_machine_list_model_tree_model_init));
 
 //-- helper
@@ -491,9 +493,7 @@ bt_machine_list_model_finalize (GObject * object)
 static void
 bt_machine_list_model_init (BtMachineListModel * self)
 {
-  self->priv =
-      G_TYPE_INSTANCE_GET_PRIVATE (self, BT_TYPE_MACHINE_LIST_MODEL,
-      BtMachineListModelPrivate);
+  self->priv = bt_machine_list_model_get_instance_private(self);
 
   self->priv->seq = g_sequence_new (NULL);
   // random int to check whether an iter belongs to our model
@@ -504,8 +504,6 @@ static void
 bt_machine_list_model_class_init (BtMachineListModelClass * klass)
 {
   GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
-
-  g_type_class_add_private (klass, sizeof (BtMachineListModelPrivate));
 
   gobject_class->finalize = bt_machine_list_model_finalize;
 }

--- a/src/ui/edit/machine-menu.c
+++ b/src/ui/edit/machine-menu.c
@@ -49,7 +49,8 @@ struct _BtMachineMenuPrivate
 
 //-- the class
 
-G_DEFINE_TYPE (BtMachineMenu, bt_machine_menu, GTK_TYPE_MENU);
+G_DEFINE_TYPE_WITH_CODE (BtMachineMenu, bt_machine_menu, GTK_TYPE_MENU, 
+    G_ADD_PRIVATE(BtMachineMenu));
 
 //-- event handler
 
@@ -416,9 +417,7 @@ bt_machine_menu_dispose (GObject * object)
 static void
 bt_machine_menu_init (BtMachineMenu * self)
 {
-  self->priv =
-      G_TYPE_INSTANCE_GET_PRIVATE (self, BT_TYPE_MACHINE_MENU,
-      BtMachineMenuPrivate);
+  self->priv = bt_machine_menu_get_instance_private(self);
   GST_DEBUG ("!!!! self=%p", self);
   self->priv->app = bt_edit_application_new ();
 }
@@ -427,8 +426,6 @@ static void
 bt_machine_menu_class_init (BtMachineMenuClass * klass)
 {
   GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
-
-  g_type_class_add_private (klass, sizeof (BtMachineMenuPrivate));
 
   gobject_class->set_property = bt_machine_menu_set_property;
   gobject_class->dispose = bt_machine_menu_dispose;

--- a/src/ui/edit/machine-preferences-dialog.c
+++ b/src/ui/edit/machine-preferences-dialog.c
@@ -68,8 +68,9 @@ static GQuark widget_parent_quark = 0;
 
 //-- the class
 
-G_DEFINE_TYPE (BtMachinePreferencesDialog, bt_machine_preferences_dialog,
-    GTK_TYPE_WINDOW);
+G_DEFINE_TYPE_WITH_CODE (BtMachinePreferencesDialog, bt_machine_preferences_dialog,
+    GTK_TYPE_WINDOW, 
+    G_ADD_PRIVATE(BtMachinePreferencesDialog));
 
 //-- event handler
 
@@ -581,9 +582,7 @@ bt_machine_preferences_dialog_dispose (GObject * object)
 static void
 bt_machine_preferences_dialog_init (BtMachinePreferencesDialog * self)
 {
-  self->priv =
-      G_TYPE_INSTANCE_GET_PRIVATE (self, BT_TYPE_MACHINE_PREFERENCES_DIALOG,
-      BtMachinePreferencesDialogPrivate);
+  self->priv = bt_machine_preferences_dialog_get_instance_private(self);
   GST_DEBUG ("!!!! self=%p", self);
   self->priv->app = bt_edit_application_new ();
 }
@@ -596,8 +595,6 @@ bt_machine_preferences_dialog_class_init (BtMachinePreferencesDialogClass *
 
   widget_parent_quark =
       g_quark_from_static_string ("BtMachinePreferencesDialog::widget-parent");
-
-  g_type_class_add_private (klass, sizeof (BtMachinePreferencesDialogPrivate));
 
   gobject_class->set_property = bt_machine_preferences_dialog_set_property;
   gobject_class->dispose = bt_machine_preferences_dialog_dispose;

--- a/src/ui/edit/machine-preset-properties-dialog.c
+++ b/src/ui/edit/machine-preset-properties-dialog.c
@@ -57,8 +57,9 @@ struct _BtMachinePresetPropertiesDialogPrivate
 
 //-- the class
 
-G_DEFINE_TYPE (BtMachinePresetPropertiesDialog,
-    bt_machine_preset_properties_dialog, GTK_TYPE_DIALOG);
+G_DEFINE_TYPE_WITH_CODE (BtMachinePresetPropertiesDialog,
+    bt_machine_preset_properties_dialog, GTK_TYPE_DIALOG, 
+    G_ADD_PRIVATE(BtMachinePresetPropertiesDialog));
 
 //-- event handler
 
@@ -332,10 +333,7 @@ static void
 bt_machine_preset_properties_dialog_init (BtMachinePresetPropertiesDialog *
     self)
 {
-  self->priv =
-      G_TYPE_INSTANCE_GET_PRIVATE (self,
-      BT_TYPE_MACHINE_PRESET_PROPERTIES_DIALOG,
-      BtMachinePresetPropertiesDialogPrivate);
+  self->priv = bt_machine_preset_properties_dialog_get_instance_private(self);
   GST_DEBUG ("!!!! self=%p", self);
   self->priv->app = bt_edit_application_new ();
 }
@@ -345,9 +343,6 @@ static void
     (BtMachinePresetPropertiesDialogClass * klass)
 {
   GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
-
-  g_type_class_add_private (klass,
-      sizeof (BtMachinePresetPropertiesDialogPrivate));
 
   gobject_class->set_property =
       bt_machine_preset_properties_dialog_set_property;

--- a/src/ui/edit/machine-properties-dialog.c
+++ b/src/ui/edit/machine-properties-dialog.c
@@ -143,8 +143,9 @@ static GQuark widget_param_num_quark = 0;       /* which parameter inside the gr
 
 //-- the class
 
-G_DEFINE_TYPE (BtMachinePropertiesDialog, bt_machine_properties_dialog,
-    GTK_TYPE_WINDOW);
+G_DEFINE_TYPE_WITH_CODE (BtMachinePropertiesDialog, bt_machine_properties_dialog,
+    GTK_TYPE_WINDOW, 
+    G_ADD_PRIVATE(BtMachinePropertiesDialog));
 
 //-- event handler helper
 
@@ -3044,9 +3045,7 @@ bt_machine_properties_dialog_finalize (GObject * object)
 static void
 bt_machine_properties_dialog_init (BtMachinePropertiesDialog * self)
 {
-  self->priv =
-      G_TYPE_INSTANCE_GET_PRIVATE (self, BT_TYPE_MACHINE_PROPERTIES_DIALOG,
-      BtMachinePropertiesDialogPrivate);
+  self->priv = bt_machine_properties_dialog_get_instance_private(self);
   GST_DEBUG ("!!!! self=%p", self);
   self->priv->app = bt_edit_application_new ();
 
@@ -3073,8 +3072,6 @@ bt_machine_properties_dialog_class_init (BtMachinePropertiesDialogClass * klass)
 
   widget_child_quark =
       g_quark_from_static_string ("BtInteractionControllerMenu::widget-child");
-
-  g_type_class_add_private (klass, sizeof (BtMachinePropertiesDialogPrivate));
 
   gobject_class->set_property = bt_machine_properties_dialog_set_property;
   gobject_class->dispose = bt_machine_properties_dialog_dispose;

--- a/src/ui/edit/machine-rename-dialog.c
+++ b/src/ui/edit/machine-rename-dialog.c
@@ -56,8 +56,9 @@ struct _BtMachineRenameDialogPrivate
 
 //-- the class
 
-G_DEFINE_TYPE (BtMachineRenameDialog, bt_machine_rename_dialog,
-    GTK_TYPE_DIALOG);
+G_DEFINE_TYPE_WITH_CODE (BtMachineRenameDialog, bt_machine_rename_dialog,
+    GTK_TYPE_DIALOG, 
+    G_ADD_PRIVATE(BtMachineRenameDialog));
 
 
 //-- event handler
@@ -258,9 +259,7 @@ bt_machine_rename_dialog_finalize (GObject * object)
 static void
 bt_machine_rename_dialog_init (BtMachineRenameDialog * self)
 {
-  self->priv =
-      G_TYPE_INSTANCE_GET_PRIVATE (self, BT_TYPE_MACHINE_RENAME_DIALOG,
-      BtMachineRenameDialogPrivate);
+  self->priv = bt_machine_rename_dialog_get_instance_private(self);
   GST_DEBUG ("!!!! self=%p", self);
   self->priv->app = bt_edit_application_new ();
 }
@@ -269,8 +268,6 @@ static void
 bt_machine_rename_dialog_class_init (BtMachineRenameDialogClass * klass)
 {
   GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
-
-  g_type_class_add_private (klass, sizeof (BtMachineRenameDialogPrivate));
 
   gobject_class->get_property = bt_machine_rename_dialog_get_property;
   gobject_class->set_property = bt_machine_rename_dialog_set_property;

--- a/src/ui/edit/main-menu.c
+++ b/src/ui/edit/main-menu.c
@@ -56,7 +56,8 @@ struct _BtMainMenuPrivate
 
 //-- the class
 
-G_DEFINE_TYPE (BtMainMenu, bt_main_menu, GTK_TYPE_MENU_BAR);
+G_DEFINE_TYPE_WITH_CODE (BtMainMenu, bt_main_menu, GTK_TYPE_MENU_BAR, 
+    G_ADD_PRIVATE(BtMainMenu));
 
 //-- event handler
 
@@ -1253,8 +1254,7 @@ bt_main_menu_dispose (GObject * object)
 static void
 bt_main_menu_init (BtMainMenu * self)
 {
-  self->priv =
-      G_TYPE_INSTANCE_GET_PRIVATE (self, BT_TYPE_MAIN_MENU, BtMainMenuPrivate);
+  self->priv = bt_main_menu_get_instance_private(self);
   GST_DEBUG ("!!!! self=%p", self);
   self->priv->app = bt_edit_application_new ();
 
@@ -1272,8 +1272,6 @@ bt_main_menu_class_init (BtMainMenuClass * klass)
 {
   GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
   GtkWidgetClass *widget_class = GTK_WIDGET_CLASS (klass);
-
-  g_type_class_add_private (klass, sizeof (BtMainMenuPrivate));
 
   gobject_class->dispose = bt_main_menu_dispose;
 

--- a/src/ui/edit/main-page-info.c
+++ b/src/ui/edit/main-page-info.c
@@ -77,7 +77,8 @@ struct _BtMainPageInfoPrivate
 
 //-- the class
 
-G_DEFINE_TYPE (BtMainPageInfo, bt_main_page_info, GTK_TYPE_BOX);
+G_DEFINE_TYPE_WITH_CODE (BtMainPageInfo, bt_main_page_info, GTK_TYPE_BOX, 
+    G_ADD_PRIVATE(BtMainPageInfo));
 
 
 //-- event handler
@@ -632,9 +633,7 @@ bt_main_page_info_dispose (GObject * object)
 static void
 bt_main_page_info_init (BtMainPageInfo * self)
 {
-  self->priv =
-      G_TYPE_INSTANCE_GET_PRIVATE (self, BT_TYPE_MAIN_PAGE_INFO,
-      BtMainPageInfoPrivate);
+  self->priv = bt_main_page_info_get_instance_private(self);
   GST_DEBUG ("!!!! self=%p", self);
   self->priv->app = bt_edit_application_new ();
 
@@ -647,8 +646,6 @@ bt_main_page_info_class_init (BtMainPageInfoClass * klass)
 {
   GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
   GtkWidgetClass *gtkwidget_class = GTK_WIDGET_CLASS (klass);
-
-  g_type_class_add_private (klass, sizeof (BtMainPageInfoPrivate));
 
   gobject_class->dispose = bt_main_page_info_dispose;
 

--- a/src/ui/edit/main-page-machines.c
+++ b/src/ui/edit/main-page-machines.c
@@ -178,7 +178,9 @@ static void bt_main_page_machines_change_logger_interface_init (gpointer const
     g_iface, gconstpointer const iface_data);
 
 G_DEFINE_TYPE_WITH_CODE (BtMainPageMachines, bt_main_page_machines,
-    GTK_TYPE_BOX, G_IMPLEMENT_INTERFACE (BT_TYPE_CHANGE_LOGGER,
+    GTK_TYPE_BOX,
+    G_ADD_PRIVATE(BtMainPageMachines)
+    G_IMPLEMENT_INTERFACE (BT_TYPE_CHANGE_LOGGER,
         bt_main_page_machines_change_logger_interface_init));
 
 enum
@@ -2612,9 +2614,7 @@ bt_main_page_machines_finalize (GObject * object)
 static void
 bt_main_page_machines_init (BtMainPageMachines * self)
 {
-  self->priv =
-      G_TYPE_INSTANCE_GET_PRIVATE (self, BT_TYPE_MAIN_PAGE_MACHINES,
-      BtMainPageMachinesPrivate);
+  self->priv = bt_main_page_machines_get_instance_private(self);
   GST_DEBUG ("!!!! self=%p", self);
   self->priv->app = bt_edit_application_new ();
   self->priv->zoom = 1.0;
@@ -2640,7 +2640,6 @@ bt_main_page_machines_class_init (BtMainPageMachinesClass * klass)
 {
   GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
   GtkWidgetClass *gtkwidget_class = GTK_WIDGET_CLASS (klass);
-  g_type_class_add_private (klass, sizeof (BtMainPageMachinesPrivate));
   gobject_class->get_property = bt_main_page_machines_get_property;
   gobject_class->dispose = bt_main_page_machines_dispose;
   gobject_class->finalize = bt_main_page_machines_finalize;

--- a/src/ui/edit/main-page-patterns.c
+++ b/src/ui/edit/main-page-patterns.c
@@ -188,7 +188,9 @@ static void bt_main_page_patterns_change_logger_interface_init (gpointer const
     g_iface, gconstpointer const iface_data);
 
 G_DEFINE_TYPE_WITH_CODE (BtMainPagePatterns, bt_main_page_patterns,
-    GTK_TYPE_BOX, G_IMPLEMENT_INTERFACE (BT_TYPE_CHANGE_LOGGER,
+    GTK_TYPE_BOX,
+    G_ADD_PRIVATE(BtMainPagePatterns)
+    G_IMPLEMENT_INTERFACE (BT_TYPE_CHANGE_LOGGER,
         bt_main_page_patterns_change_logger_interface_init));
 
 
@@ -3873,9 +3875,7 @@ bt_main_page_patterns_finalize (GObject * object)
 static void
 bt_main_page_patterns_init (BtMainPagePatterns * self)
 {
-  self->priv =
-      G_TYPE_INSTANCE_GET_PRIVATE (self, BT_TYPE_MAIN_PAGE_PATTERNS,
-      BtMainPagePatternsPrivate);
+  self->priv = bt_main_page_patterns_get_instance_private(self);
   GST_DEBUG ("!!!! self=%p", self);
   self->priv->app = bt_edit_application_new ();
 
@@ -3904,8 +3904,6 @@ bt_main_page_patterns_class_init (BtMainPagePatternsClass * klass)
 
   pattern_atom =
       gdk_atom_intern_static_string ("application/buzztrax::pattern");
-
-  g_type_class_add_private (klass, sizeof (BtMainPagePatternsPrivate));
 
   gobject_class->dispose = bt_main_page_patterns_dispose;
   gobject_class->finalize = bt_main_page_patterns_finalize;

--- a/src/ui/edit/main-page-sequence.c
+++ b/src/ui/edit/main-page-sequence.c
@@ -201,7 +201,9 @@ static void bt_main_page_sequence_change_logger_interface_init (gpointer const
     g_iface, gconstpointer const iface_data);
 
 G_DEFINE_TYPE_WITH_CODE (BtMainPageSequence, bt_main_page_sequence,
-    GTK_TYPE_BOX, G_IMPLEMENT_INTERFACE (BT_TYPE_CHANGE_LOGGER,
+    GTK_TYPE_BOX,
+    G_ADD_PRIVATE(BtMainPageSequence)
+    G_IMPLEMENT_INTERFACE (BT_TYPE_CHANGE_LOGGER,
         bt_main_page_sequence_change_logger_interface_init));
 
 // this only works for 4/4 meassure
@@ -4707,9 +4709,7 @@ bt_main_page_sequence_finalize (GObject * object)
 static void
 bt_main_page_sequence_init (BtMainPageSequence * self)
 {
-  self->priv =
-      G_TYPE_INSTANCE_GET_PRIVATE (self, BT_TYPE_MAIN_PAGE_SEQUENCE,
-      BtMainPageSequencePrivate);
+  self->priv = bt_main_page_sequence_get_instance_private(self);
   GST_DEBUG ("!!!! self=%p", self);
   self->priv->app = bt_edit_application_new ();
 
@@ -4750,8 +4750,6 @@ bt_main_page_sequence_class_init (BtMainPageSequenceClass * klass)
       g_quark_from_static_string ("BtMainPageSequence::skip-update");
   machine_for_track =
       g_quark_from_static_string ("BtMainPageSequence::machine_for_track");
-
-  g_type_class_add_private (klass, sizeof (BtMainPageSequencePrivate));
 
   gobject_class->get_property = bt_main_page_sequence_get_property;
   gobject_class->set_property = bt_main_page_sequence_set_property;

--- a/src/ui/edit/main-page-waves.c
+++ b/src/ui/edit/main-page-waves.c
@@ -115,7 +115,8 @@ struct _BtMainPageWavesPrivate
 
 //-- the class
 
-G_DEFINE_TYPE (BtMainPageWaves, bt_main_page_waves, GTK_TYPE_BOX);
+G_DEFINE_TYPE_WITH_CODE (BtMainPageWaves, bt_main_page_waves, GTK_TYPE_BOX, 
+    G_ADD_PRIVATE(BtMainPageWaves));
 
 
 //-- event handler helper
@@ -1607,9 +1608,7 @@ bt_main_page_waves_dispose (GObject * object)
 static void
 bt_main_page_waves_init (BtMainPageWaves * self)
 {
-  self->priv =
-      G_TYPE_INSTANCE_GET_PRIVATE (self, BT_TYPE_MAIN_PAGE_WAVES,
-      BtMainPageWavesPrivate);
+  self->priv = bt_main_page_waves_get_instance_private(self);
   GST_DEBUG ("!!!! self=%p", self);
   self->priv->app = bt_edit_application_new ();
   self->priv->settings = bt_settings_make ();
@@ -1626,8 +1625,6 @@ static void
 bt_main_page_waves_class_init (BtMainPageWavesClass * klass)
 {
   GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
-
-  g_type_class_add_private (klass, sizeof (BtMainPageWavesPrivate));
 
   gobject_class->dispose = bt_main_page_waves_dispose;
 }

--- a/src/ui/edit/main-pages.c
+++ b/src/ui/edit/main-pages.c
@@ -61,7 +61,8 @@ struct _BtMainPagesPrivate
 
 //-- the class
 
-G_DEFINE_TYPE (BtMainPages, bt_main_pages, GTK_TYPE_NOTEBOOK);
+G_DEFINE_TYPE_WITH_CODE (BtMainPages, bt_main_pages, GTK_TYPE_NOTEBOOK, 
+    G_ADD_PRIVATE(BtMainPages));
 
 
 //-- event handler
@@ -286,9 +287,7 @@ bt_main_pages_dispose (GObject * object)
 static void
 bt_main_pages_init (BtMainPages * self)
 {
-  self->priv =
-      G_TYPE_INSTANCE_GET_PRIVATE (self, BT_TYPE_MAIN_PAGES,
-      BtMainPagesPrivate);
+  self->priv = bt_main_pages_get_instance_private(self);
   GST_DEBUG ("!!!! self=%p", self);
   self->priv->app = bt_edit_application_new ();
 }
@@ -297,8 +296,6 @@ static void
 bt_main_pages_class_init (BtMainPagesClass * klass)
 {
   GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
-
-  g_type_class_add_private (klass, sizeof (BtMainPagesPrivate));
 
   gobject_class->get_property = bt_main_pages_get_property;
   gobject_class->dispose = bt_main_pages_dispose;

--- a/src/ui/edit/main-statusbar.c
+++ b/src/ui/edit/main-statusbar.c
@@ -74,7 +74,8 @@ struct _BtMainStatusbarPrivate
 
 //-- the class
 
-G_DEFINE_TYPE (BtMainStatusbar, bt_main_statusbar, GTK_TYPE_BOX);
+G_DEFINE_TYPE_WITH_CODE (BtMainStatusbar, bt_main_statusbar, GTK_TYPE_BOX, 
+    G_ADD_PRIVATE(BtMainStatusbar));
 
 
 //-- helper
@@ -426,9 +427,7 @@ bt_main_statusbar_dispose (GObject * object)
 static void
 bt_main_statusbar_init (BtMainStatusbar * self)
 {
-  self->priv =
-      G_TYPE_INSTANCE_GET_PRIVATE (self, BT_TYPE_MAIN_STATUSBAR,
-      BtMainStatusbarPrivate);
+  self->priv = bt_main_statusbar_get_instance_private(self);
   GST_DEBUG ("!!!! self=%p", self);
   self->priv->app = bt_edit_application_new ();
 }
@@ -437,8 +436,6 @@ static void
 bt_main_statusbar_class_init (BtMainStatusbarClass * klass)
 {
   GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
-
-  g_type_class_add_private (klass, sizeof (BtMainStatusbarPrivate));
 
   gobject_class->set_property = bt_main_statusbar_set_property;
   gobject_class->dispose = bt_main_statusbar_dispose;

--- a/src/ui/edit/main-toolbar.c
+++ b/src/ui/edit/main-toolbar.c
@@ -87,7 +87,8 @@ static void on_song_volume_changed (GstElement * gain, GParamSpec * arg,
 
 //-- the class
 
-G_DEFINE_TYPE (BtMainToolbar, bt_main_toolbar, GTK_TYPE_TOOLBAR);
+G_DEFINE_TYPE_WITH_CODE (BtMainToolbar, bt_main_toolbar, GTK_TYPE_TOOLBAR, 
+    G_ADD_PRIVATE(BtMainToolbar));
 
 
 //-- event handler
@@ -1048,9 +1049,7 @@ bt_main_toolbar_finalize (GObject * object)
 static void
 bt_main_toolbar_init (BtMainToolbar * self)
 {
-  self->priv =
-      G_TYPE_INSTANCE_GET_PRIVATE (self, BT_TYPE_MAIN_TOOLBAR,
-      BtMainToolbarPrivate);
+  self->priv = bt_main_toolbar_get_instance_private(self);
   GST_DEBUG ("!!!! self=%p", self);
   self->priv->app = bt_edit_application_new ();
   g_mutex_init (&self->priv->lock);
@@ -1064,8 +1063,6 @@ bt_main_toolbar_class_init (BtMainToolbarClass * klass)
   GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
 
   bus_msg_level_quark = g_quark_from_static_string ("level");
-
-  g_type_class_add_private (klass, sizeof (BtMainToolbarPrivate));
 
   gobject_class->dispose = bt_main_toolbar_dispose;
   gobject_class->finalize = bt_main_toolbar_finalize;

--- a/src/ui/edit/main-window.c
+++ b/src/ui/edit/main-window.c
@@ -71,7 +71,8 @@ static gint n_drop_types = sizeof (drop_types) / sizeof (GtkTargetEntry);
 
 //-- the class
 
-G_DEFINE_TYPE (BtMainWindow, bt_main_window, GTK_TYPE_WINDOW);
+G_DEFINE_TYPE_WITH_CODE (BtMainWindow, bt_main_window, GTK_TYPE_WINDOW, 
+    G_ADD_PRIVATE(BtMainWindow));
 
 
 //-- helper methods
@@ -1155,9 +1156,7 @@ bt_main_window_finalize (GObject * object)
 static void
 bt_main_window_init (BtMainWindow * self)
 {
-  self->priv =
-      G_TYPE_INSTANCE_GET_PRIVATE (self, BT_TYPE_MAIN_WINDOW,
-      BtMainWindowPrivate);
+  self->priv = bt_main_window_get_instance_private(self);
   GST_DEBUG ("!!!! self=%p", self);
   self->priv->app = bt_edit_application_new ();
 }
@@ -1166,8 +1165,6 @@ static void
 bt_main_window_class_init (BtMainWindowClass * klass)
 {
   GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
-
-  g_type_class_add_private (klass, sizeof (BtMainWindowPrivate));
 
   gobject_class->get_property = bt_main_window_get_property;
   gobject_class->dispose = bt_main_window_dispose;

--- a/src/ui/edit/missing-framework-elements-dialog.c
+++ b/src/ui/edit/missing-framework-elements-dialog.c
@@ -66,8 +66,9 @@ struct _BtMissingFrameworkElementsDialogPrivate
 
 //-- the class
 
-G_DEFINE_TYPE (BtMissingFrameworkElementsDialog,
-    bt_missing_framework_elements_dialog, GTK_TYPE_DIALOG);
+G_DEFINE_TYPE_WITH_CODE (BtMissingFrameworkElementsDialog,
+    bt_missing_framework_elements_dialog, GTK_TYPE_DIALOG, 
+    G_ADD_PRIVATE(BtMissingFrameworkElementsDialog));
 
 
 //-- event handler
@@ -350,10 +351,7 @@ static void
 bt_missing_framework_elements_dialog_init (BtMissingFrameworkElementsDialog *
     self)
 {
-  self->priv =
-      G_TYPE_INSTANCE_GET_PRIVATE (self,
-      BT_TYPE_MISSING_FRAMEWORK_ELEMENTS_DIALOG,
-      BtMissingFrameworkElementsDialogPrivate);
+  self->priv = bt_missing_framework_elements_dialog_get_instance_private(self);
   GST_DEBUG ("!!!! self=%p", self);
   self->priv->app = bt_edit_application_new ();
 }
@@ -363,9 +361,6 @@ static void
     (BtMissingFrameworkElementsDialogClass * klass)
 {
   GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
-
-  g_type_class_add_private (klass,
-      sizeof (BtMissingFrameworkElementsDialogPrivate));
 
   gobject_class->set_property =
       bt_missing_framework_elements_dialog_set_property;

--- a/src/ui/edit/missing-song-elements-dialog.c
+++ b/src/ui/edit/missing-song-elements-dialog.c
@@ -52,8 +52,9 @@ struct _BtMissingSongElementsDialogPrivate
 
 //-- the class
 
-G_DEFINE_TYPE (BtMissingSongElementsDialog, bt_missing_song_elements_dialog,
-    GTK_TYPE_DIALOG);
+G_DEFINE_TYPE_WITH_CODE (BtMissingSongElementsDialog, bt_missing_song_elements_dialog,
+    GTK_TYPE_DIALOG, 
+    G_ADD_PRIVATE(BtMissingSongElementsDialog));
 
 
 //-- event handler
@@ -213,9 +214,7 @@ bt_missing_song_elements_dialog_dispose (GObject * object)
 static void
 bt_missing_song_elements_dialog_init (BtMissingSongElementsDialog * self)
 {
-  self->priv =
-      G_TYPE_INSTANCE_GET_PRIVATE (self, BT_TYPE_MISSING_SONG_ELEMENTS_DIALOG,
-      BtMissingSongElementsDialogPrivate);
+  self->priv = bt_missing_song_elements_dialog_get_instance_private(self);
   GST_DEBUG ("!!!! self=%p", self);
   self->priv->app = bt_edit_application_new ();
 }
@@ -225,8 +224,6 @@ bt_missing_song_elements_dialog_class_init (BtMissingSongElementsDialogClass *
     klass)
 {
   GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
-
-  g_type_class_add_private (klass, sizeof (BtMissingSongElementsDialogPrivate));
 
   gobject_class->set_property = bt_missing_song_elements_dialog_set_property;
   gobject_class->dispose = bt_missing_song_elements_dialog_dispose;

--- a/src/ui/edit/object-list-model.c
+++ b/src/ui/edit/object-list-model.c
@@ -52,6 +52,7 @@ static void bt_object_list_model_tree_model_init (gpointer const g_iface,
     gpointer const iface_data);
 
 G_DEFINE_TYPE_WITH_CODE (BtObjectListModel, bt_object_list_model, G_TYPE_OBJECT,
+    G_ADD_PRIVATE(BtObjectListModel)
     G_IMPLEMENT_INTERFACE (GTK_TYPE_TREE_MODEL,
         bt_object_list_model_tree_model_init));
 
@@ -408,9 +409,7 @@ bt_object_list_model_finalize (GObject * object)
 static void
 bt_object_list_model_init (BtObjectListModel * self)
 {
-  self->priv =
-      G_TYPE_INSTANCE_GET_PRIVATE (self, BT_TYPE_OBJECT_LIST_MODEL,
-      BtObjectListModelPrivate);
+  self->priv = bt_object_list_model_get_instance_private(self);
 
   self->priv->seq = g_sequence_new (NULL);
   // random int to check whether an iter belongs to our model
@@ -421,8 +420,6 @@ static void
 bt_object_list_model_class_init (BtObjectListModelClass * klass)
 {
   GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
-
-  g_type_class_add_private (klass, sizeof (BtObjectListModelPrivate));
 
   gobject_class->dispose = bt_object_list_model_dispose;
   gobject_class->finalize = bt_object_list_model_finalize;

--- a/src/ui/edit/pattern-list-model.c
+++ b/src/ui/edit/pattern-list-model.c
@@ -68,7 +68,9 @@ static void bt_pattern_list_model_tree_model_init (gpointer const g_iface,
     gpointer const iface_data);
 
 G_DEFINE_TYPE_WITH_CODE (BtPatternListModel, bt_pattern_list_model,
-    G_TYPE_OBJECT, G_IMPLEMENT_INTERFACE (GTK_TYPE_TREE_MODEL,
+    G_TYPE_OBJECT,
+    G_ADD_PRIVATE(BtPatternListModel)
+    G_IMPLEMENT_INTERFACE (GTK_TYPE_TREE_MODEL,
         bt_pattern_list_model_tree_model_init));
 
 //-- helper
@@ -617,9 +619,7 @@ bt_pattern_list_model_finalize (GObject * object)
 static void
 bt_pattern_list_model_init (BtPatternListModel * self)
 {
-  self->priv =
-      G_TYPE_INSTANCE_GET_PRIVATE (self, BT_TYPE_PATTERN_LIST_MODEL,
-      BtPatternListModelPrivate);
+  self->priv = bt_pattern_list_model_get_instance_private(self);
 
   self->priv->seq = g_sequence_new (NULL);
   // random int to check whether an iter belongs to our model
@@ -630,8 +630,6 @@ static void
 bt_pattern_list_model_class_init (BtPatternListModelClass * klass)
 {
   GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
-
-  g_type_class_add_private (klass, sizeof (BtPatternListModelPrivate));
 
   gobject_class->finalize = bt_pattern_list_model_finalize;
 }

--- a/src/ui/edit/pattern-properties-dialog.c
+++ b/src/ui/edit/pattern-properties-dialog.c
@@ -61,8 +61,9 @@ struct _BtPatternPropertiesDialogPrivate
 
 //-- the class
 
-G_DEFINE_TYPE (BtPatternPropertiesDialog, bt_pattern_properties_dialog,
-    GTK_TYPE_DIALOG);
+G_DEFINE_TYPE_WITH_CODE (BtPatternPropertiesDialog, bt_pattern_properties_dialog,
+    GTK_TYPE_DIALOG, 
+    G_ADD_PRIVATE(BtPatternPropertiesDialog));
 
 
 //-- event handler
@@ -355,9 +356,7 @@ bt_pattern_properties_dialog_finalize (GObject * object)
 static void
 bt_pattern_properties_dialog_init (BtPatternPropertiesDialog * self)
 {
-  self->priv =
-      G_TYPE_INSTANCE_GET_PRIVATE (self, BT_TYPE_PATTERN_PROPERTIES_DIALOG,
-      BtPatternPropertiesDialogPrivate);
+  self->priv = bt_pattern_properties_dialog_get_instance_private(self);
   GST_DEBUG ("!!!! self=%p", self);
   self->priv->app = bt_edit_application_new ();
 }
@@ -366,8 +365,6 @@ static void
 bt_pattern_properties_dialog_class_init (BtPatternPropertiesDialogClass * klass)
 {
   GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
-
-  g_type_class_add_private (klass, sizeof (BtPatternPropertiesDialogPrivate));
 
   gobject_class->get_property = bt_pattern_properties_dialog_get_property;
   gobject_class->set_property = bt_pattern_properties_dialog_set_property;

--- a/src/ui/edit/playback-controller-ic.c
+++ b/src/ui/edit/playback-controller-ic.c
@@ -40,8 +40,9 @@ struct _BtPlaybackControllerIcPrivate
 
 //-- the class
 
-G_DEFINE_TYPE (BtPlaybackControllerIc, bt_playback_controller_ic,
-    G_TYPE_OBJECT);
+G_DEFINE_TYPE_WITH_CODE (BtPlaybackControllerIc, bt_playback_controller_ic,
+    G_TYPE_OBJECT, 
+    G_ADD_PRIVATE(BtPlaybackControllerIc));
 
 //-- signal handlers
 
@@ -295,9 +296,7 @@ bt_playback_controller_ic_finalize (GObject * object)
 static void
 bt_playback_controller_ic_init (BtPlaybackControllerIc * self)
 {
-  self->priv =
-      G_TYPE_INSTANCE_GET_PRIVATE (self, BT_TYPE_PLAYBACK_CONTROLLER_IC,
-      BtPlaybackControllerIcPrivate);
+  self->priv = bt_playback_controller_ic_get_instance_private(self);
   GST_DEBUG ("!!!! self=%p", self);
   /* this is created from the app, we need to avoid a ref-cycle */
   self->priv->app = bt_edit_application_new ();
@@ -312,8 +311,6 @@ static void
 bt_playback_controller_ic_class_init (BtPlaybackControllerIcClass * klass)
 {
   GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
-
-  g_type_class_add_private (klass, sizeof (BtPlaybackControllerIcPrivate));
 
   gobject_class->dispose = bt_playback_controller_ic_dispose;
   gobject_class->finalize = bt_playback_controller_ic_finalize;

--- a/src/ui/edit/playback-controller-socket.c
+++ b/src/ui/edit/playback-controller-socket.c
@@ -90,8 +90,9 @@ struct _BtPlaybackControllerSocketPrivate
 
 //-- the class
 
-G_DEFINE_TYPE (BtPlaybackControllerSocket, bt_playback_controller_socket,
-    G_TYPE_OBJECT);
+G_DEFINE_TYPE_WITH_CODE (BtPlaybackControllerSocket, bt_playback_controller_socket,
+    G_TYPE_OBJECT, 
+    G_ADD_PRIVATE(BtPlaybackControllerSocket));
 
 //-- helper methods
 
@@ -654,9 +655,7 @@ bt_playback_controller_socket_finalize (GObject * object)
 static void
 bt_playback_controller_socket_init (BtPlaybackControllerSocket * self)
 {
-  self->priv =
-      G_TYPE_INSTANCE_GET_PRIVATE (self, BT_TYPE_PLAYBACK_CONTROLLER_SOCKET,
-      BtPlaybackControllerSocketPrivate);
+  self->priv = bt_playback_controller_socket_get_instance_private(self);
   GST_DEBUG ("!!!! self=%p", self);
   /* this is created from the app, we need to avoid a ref-cycle */
   self->priv->app = bt_edit_application_new ();
@@ -676,8 +675,6 @@ bt_playback_controller_socket_class_init (BtPlaybackControllerSocketClass *
     klass)
 {
   GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
-
-  g_type_class_add_private (klass, sizeof (BtPlaybackControllerSocketPrivate));
 
   gobject_class->dispose = bt_playback_controller_socket_dispose;
   gobject_class->finalize = bt_playback_controller_socket_finalize;

--- a/src/ui/edit/preset-list-model.c
+++ b/src/ui/edit/preset-list-model.c
@@ -53,7 +53,9 @@ static void bt_preset_list_model_tree_model_init (gpointer const g_iface,
     gpointer const iface_data);
 
 G_DEFINE_TYPE_WITH_CODE (BtPresetListModel, bt_preset_list_model,
-    G_TYPE_OBJECT, G_IMPLEMENT_INTERFACE (GTK_TYPE_TREE_MODEL,
+    G_TYPE_OBJECT,
+    G_ADD_PRIVATE(BtPresetListModel)
+    G_IMPLEMENT_INTERFACE (GTK_TYPE_TREE_MODEL,
         bt_preset_list_model_tree_model_init));
 
 //-- helper
@@ -453,9 +455,7 @@ bt_preset_list_model_finalize (GObject * object)
 static void
 bt_preset_list_model_init (BtPresetListModel * self)
 {
-  self->priv =
-      G_TYPE_INSTANCE_GET_PRIVATE (self, BT_TYPE_PRESET_LIST_MODEL,
-      BtPresetListModelPrivate);
+  self->priv = bt_preset_list_model_get_instance_private(self);
 
   self->priv->seq = g_sequence_new (NULL);
   // random int to check whether an iter belongs to our model
@@ -466,8 +466,6 @@ static void
 bt_preset_list_model_class_init (BtPresetListModelClass * klass)
 {
   GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
-
-  g_type_class_add_private (klass, sizeof (BtPresetListModelPrivate));
 
   singleton_quark = g_quark_from_static_string ("BtPresetListModel::singleton");
 

--- a/src/ui/edit/render-dialog.c
+++ b/src/ui/edit/render-dialog.c
@@ -86,7 +86,8 @@ static void on_format_menu_changed (GtkComboBox * menu, gpointer user_data);
 
 //-- the class
 
-G_DEFINE_TYPE (BtRenderDialog, bt_render_dialog, GTK_TYPE_DIALOG);
+G_DEFINE_TYPE_WITH_CODE (BtRenderDialog, bt_render_dialog, GTK_TYPE_DIALOG, 
+    G_ADD_PRIVATE(BtRenderDialog));
 
 
 //-- enums
@@ -818,9 +819,7 @@ bt_render_dialog_finalize (GObject * object)
 static void
 bt_render_dialog_init (BtRenderDialog * self)
 {
-  self->priv =
-      G_TYPE_INSTANCE_GET_PRIVATE (self, BT_TYPE_RENDER_DIALOG,
-      BtRenderDialogPrivate);
+  self->priv = bt_render_dialog_get_instance_private(self);
   GST_DEBUG ("!!!! self=%p", self);
   self->priv->app = bt_edit_application_new ();
 }
@@ -829,8 +828,6 @@ static void
 bt_render_dialog_class_init (BtRenderDialogClass * klass)
 {
   GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
-
-  g_type_class_add_private (klass, sizeof (BtRenderDialogPrivate));
 
   gobject_class->dispose = bt_render_dialog_dispose;
   gobject_class->finalize = bt_render_dialog_finalize;

--- a/src/ui/edit/sequence-grid-model.c
+++ b/src/ui/edit/sequence-grid-model.c
@@ -107,7 +107,9 @@ static void bt_sequence_grid_model_tree_model_init (gpointer const g_iface,
     gpointer const iface_data);
 
 G_DEFINE_TYPE_WITH_CODE (BtSequenceGridModel, bt_sequence_grid_model,
-    G_TYPE_OBJECT, G_IMPLEMENT_INTERFACE (GTK_TYPE_TREE_MODEL,
+    G_TYPE_OBJECT,
+    G_ADD_PRIVATE(BtSequenceGridModel)
+    G_IMPLEMENT_INTERFACE (GTK_TYPE_TREE_MODEL,
         bt_sequence_grid_model_tree_model_init));
 
 //-- helper
@@ -682,9 +684,7 @@ bt_sequence_grid_model_finalize (GObject * object)
 static void
 bt_sequence_grid_model_init (BtSequenceGridModel * self)
 {
-  self->priv =
-      G_TYPE_INSTANCE_GET_PRIVATE (self, BT_TYPE_SEQUENCE_GRID_MODEL,
-      BtSequenceGridModelPrivate);
+  self->priv = bt_sequence_grid_model_get_instance_private(self);
 
   // random int to check whether an iter belongs to our model
   self->priv->stamp = g_random_int ();
@@ -694,8 +694,6 @@ static void
 bt_sequence_grid_model_class_init (BtSequenceGridModelClass * klass)
 {
   GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
-
-  g_type_class_add_private (klass, sizeof (BtSequenceGridModelPrivate));
 
   gobject_class->set_property = bt_sequence_grid_model_set_property;
   gobject_class->get_property = bt_sequence_grid_model_get_property;

--- a/src/ui/edit/sequence-view.c
+++ b/src/ui/edit/sequence-view.c
@@ -63,7 +63,8 @@ struct _BtSequenceViewPrivate
 
 //-- the class
 
-G_DEFINE_TYPE (BtSequenceView, bt_sequence_view, GTK_TYPE_TREE_VIEW);
+G_DEFINE_TYPE_WITH_CODE (BtSequenceView, bt_sequence_view, GTK_TYPE_TREE_VIEW, 
+    G_ADD_PRIVATE(BtSequenceView));
 
 
 //-- event handler
@@ -276,9 +277,7 @@ bt_sequence_view_dispose (GObject * object)
 static void
 bt_sequence_view_init (BtSequenceView * self)
 {
-  self->priv =
-      G_TYPE_INSTANCE_GET_PRIVATE (self, BT_TYPE_SEQUENCE_VIEW,
-      BtSequenceViewPrivate);
+  self->priv = bt_sequence_view_get_instance_private(self);
   GST_DEBUG ("!!!! self=%p", self);
   self->priv->app = bt_edit_application_new ();
 }
@@ -288,8 +287,6 @@ bt_sequence_view_class_init (BtSequenceViewClass * klass)
 {
   GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
   GtkWidgetClass *gtkwidget_class = GTK_WIDGET_CLASS (klass);
-
-  g_type_class_add_private (klass, sizeof (BtSequenceViewPrivate));
 
   gobject_class->set_property = bt_sequence_view_set_property;
   gobject_class->dispose = bt_sequence_view_dispose;

--- a/src/ui/edit/settings-dialog.c
+++ b/src/ui/edit/settings-dialog.c
@@ -68,7 +68,8 @@ struct _BtSettingsDialogPrivate
 
 //-- the class
 
-G_DEFINE_TYPE (BtSettingsDialog, bt_settings_dialog, GTK_TYPE_DIALOG);
+G_DEFINE_TYPE_WITH_CODE (BtSettingsDialog, bt_settings_dialog, GTK_TYPE_DIALOG, 
+    G_ADD_PRIVATE(BtSettingsDialog));
 
 
 //-- enums
@@ -415,9 +416,7 @@ bt_settings_dialog_dispose (GObject * object)
 static void
 bt_settings_dialog_init (BtSettingsDialog * self)
 {
-  self->priv =
-      G_TYPE_INSTANCE_GET_PRIVATE (self, BT_TYPE_SETTINGS_DIALOG,
-      BtSettingsDialogPrivate);
+  self->priv = bt_settings_dialog_get_instance_private(self);
   GST_DEBUG ("!!!! self=%p", self);
   self->priv->app = bt_edit_application_new ();
 }
@@ -426,8 +425,6 @@ static void
 bt_settings_dialog_class_init (BtSettingsDialogClass * klass)
 {
   GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
-
-  g_type_class_add_private (klass, sizeof (BtSettingsDialogPrivate));
 
   gobject_class->set_property = bt_settings_dialog_set_property;
   gobject_class->get_property = bt_settings_dialog_get_property;

--- a/src/ui/edit/settings-page-audiodevices.c
+++ b/src/ui/edit/settings-page-audiodevices.c
@@ -66,8 +66,9 @@ struct _BtSettingsPageAudiodevicesPrivate
 
 //-- the class
 
-G_DEFINE_TYPE (BtSettingsPageAudiodevices, bt_settings_page_audiodevices,
-    GTK_TYPE_GRID);
+G_DEFINE_TYPE_WITH_CODE (BtSettingsPageAudiodevices, bt_settings_page_audiodevices,
+    GTK_TYPE_GRID,
+    G_ADD_PRIVATE(BtSettingsPageAudiodevices));
 
 //-- helper
 
@@ -546,9 +547,7 @@ bt_settings_page_audiodevices_finalize (GObject * object)
 static void
 bt_settings_page_audiodevices_init (BtSettingsPageAudiodevices * self)
 {
-  self->priv =
-      G_TYPE_INSTANCE_GET_PRIVATE (self, BT_TYPE_SETTINGS_PAGE_AUDIODEVICES,
-      BtSettingsPageAudiodevicesPrivate);
+  self->priv = bt_settings_page_audiodevices_get_instance_private(self);
   GST_DEBUG ("!!!! self=%p", self);
   self->priv->app = bt_edit_application_new ();
 }
@@ -558,8 +557,6 @@ bt_settings_page_audiodevices_class_init (BtSettingsPageAudiodevicesClass *
     klass)
 {
   GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
-
-  g_type_class_add_private (klass, sizeof (BtSettingsPageAudiodevicesPrivate));
 
   gobject_class->dispose = bt_settings_page_audiodevices_dispose;
   gobject_class->finalize = bt_settings_page_audiodevices_finalize;

--- a/src/ui/edit/settings-page-directories.c
+++ b/src/ui/edit/settings-page-directories.c
@@ -37,8 +37,9 @@ struct _BtSettingsPageDirectoriesPrivate
 
 //-- the class
 
-G_DEFINE_TYPE (BtSettingsPageDirectories, bt_settings_page_directories,
-    GTK_TYPE_GRID);
+G_DEFINE_TYPE_WITH_CODE (BtSettingsPageDirectories, bt_settings_page_directories,
+    GTK_TYPE_GRID, 
+    G_ADD_PRIVATE(BtSettingsPageDirectories));
 
 
 //-- event handler
@@ -199,9 +200,7 @@ bt_settings_page_directories_finalize (GObject * object)
 static void
 bt_settings_page_directories_init (BtSettingsPageDirectories * self)
 {
-  self->priv =
-      G_TYPE_INSTANCE_GET_PRIVATE (self, BT_TYPE_SETTINGS_PAGE_DIRECTORIES,
-      BtSettingsPageDirectoriesPrivate);
+  self->priv = bt_settings_page_directories_get_instance_private(self);
   GST_DEBUG ("!!!! self=%p", self);
   self->priv->app = bt_edit_application_new ();
 }
@@ -210,8 +209,6 @@ static void
 bt_settings_page_directories_class_init (BtSettingsPageDirectoriesClass * klass)
 {
   GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
-
-  g_type_class_add_private (klass, sizeof (BtSettingsPageDirectoriesPrivate));
 
   gobject_class->dispose = bt_settings_page_directories_dispose;
   gobject_class->finalize = bt_settings_page_directories_finalize;

--- a/src/ui/edit/settings-page-interaction-controller.c
+++ b/src/ui/edit/settings-page-interaction-controller.c
@@ -76,8 +76,10 @@ struct _BtSettingsPageInteractionControllerPrivate
 
 //-- the class
 
-G_DEFINE_TYPE (BtSettingsPageInteractionController,
-    bt_settings_page_interaction_controller, GTK_TYPE_GRID);
+G_DEFINE_TYPE_WITH_CODE (BtSettingsPageInteractionController,
+    bt_settings_page_interaction_controller,
+    GTK_TYPE_GRID, 
+    G_ADD_PRIVATE(BtSettingsPageInteractionController));
 
 //-- helper
 
@@ -573,10 +575,7 @@ static void
     bt_settings_page_interaction_controller_init
     (BtSettingsPageInteractionController * self)
 {
-  self->priv =
-      G_TYPE_INSTANCE_GET_PRIVATE (self,
-      BT_TYPE_SETTINGS_PAGE_INTERACTION_CONTROLLER,
-      BtSettingsPageInteractionControllerPrivate);
+  self->priv = bt_settings_page_interaction_controller_get_instance_private(self);
   GST_DEBUG ("!!!! self=%p", self);
   self->priv->app = bt_edit_application_new ();
 }
@@ -586,9 +585,6 @@ static void
     (BtSettingsPageInteractionControllerClass * klass)
 {
   GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
-
-  g_type_class_add_private (klass,
-      sizeof (BtSettingsPageInteractionControllerPrivate));
 
   gobject_class->set_property =
       bt_settings_page_interaction_controller_set_property;

--- a/src/ui/edit/settings-page-playback-controller.c
+++ b/src/ui/edit/settings-page-playback-controller.c
@@ -106,8 +106,9 @@ struct _BtSettingsPagePlaybackControllerPrivate
 
 //-- the class
 
-G_DEFINE_TYPE (BtSettingsPagePlaybackController,
-    bt_settings_page_playback_controller, GTK_TYPE_GRID);
+G_DEFINE_TYPE_WITH_CODE (BtSettingsPagePlaybackController,
+    bt_settings_page_playback_controller, GTK_TYPE_GRID, 
+    G_ADD_PRIVATE(BtSettingsPagePlaybackController));
 
 
 //-- helper
@@ -678,10 +679,7 @@ static void
 bt_settings_page_playback_controller_init (BtSettingsPagePlaybackController *
     self)
 {
-  self->priv =
-      G_TYPE_INSTANCE_GET_PRIVATE (self,
-      BT_TYPE_SETTINGS_PAGE_PLAYBACK_CONTROLLER,
-      BtSettingsPagePlaybackControllerPrivate);
+  self->priv = bt_settings_page_playback_controller_get_instance_private(self);
   GST_DEBUG ("!!!! self=%p", self);
   self->priv->app = bt_edit_application_new ();
   g_object_get (self->priv->app, "settings", &self->priv->settings, NULL);
@@ -692,9 +690,6 @@ static void
     (BtSettingsPagePlaybackControllerClass * klass)
 {
   GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
-
-  g_type_class_add_private (klass,
-      sizeof (BtSettingsPagePlaybackControllerPrivate));
 
   gobject_class->dispose = bt_settings_page_playback_controller_dispose;
 }

--- a/src/ui/edit/settings-page-shortcuts.c
+++ b/src/ui/edit/settings-page-shortcuts.c
@@ -59,8 +59,9 @@ struct _BtSettingsPageShortcutsPrivate
 
 //-- the class
 
-G_DEFINE_TYPE (BtSettingsPageShortcuts, bt_settings_page_shortcuts,
-    GTK_TYPE_GRID);
+G_DEFINE_TYPE_WITH_CODE (BtSettingsPageShortcuts, bt_settings_page_shortcuts,
+    GTK_TYPE_GRID, 
+    G_ADD_PRIVATE(BtSettingsPageShortcuts));
 
 
 
@@ -154,9 +155,7 @@ bt_settings_page_shortcuts_finalize (GObject * object)
 static void
 bt_settings_page_shortcuts_init (BtSettingsPageShortcuts * self)
 {
-  self->priv =
-      G_TYPE_INSTANCE_GET_PRIVATE (self, BT_TYPE_SETTINGS_PAGE_SHORTCUTS,
-      BtSettingsPageShortcutsPrivate);
+  self->priv = bt_settings_page_shortcuts_get_instance_private(self);
   GST_DEBUG ("!!!! self=%p", self);
   self->priv->app = bt_edit_application_new ();
 }
@@ -165,8 +164,6 @@ static void
 bt_settings_page_shortcuts_class_init (BtSettingsPageShortcutsClass * klass)
 {
   GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
-
-  g_type_class_add_private (klass, sizeof (BtSettingsPageShortcutsPrivate));
 
   gobject_class->dispose = bt_settings_page_shortcuts_dispose;
   gobject_class->finalize = bt_settings_page_shortcuts_finalize;

--- a/src/ui/edit/settings-page-ui.c
+++ b/src/ui/edit/settings-page-ui.c
@@ -44,7 +44,8 @@ struct _BtSettingsPageUIPrivate
 
 //-- the class
 
-G_DEFINE_TYPE (BtSettingsPageUI, bt_settings_page_ui, GTK_TYPE_GRID);
+G_DEFINE_TYPE_WITH_CODE (BtSettingsPageUI, bt_settings_page_ui, GTK_TYPE_GRID, 
+    G_ADD_PRIVATE(BtSettingsPageUI));
 
 //-- event handler
 
@@ -166,9 +167,7 @@ bt_settings_page_ui_finalize (GObject * object)
 static void
 bt_settings_page_ui_init (BtSettingsPageUI * self)
 {
-  self->priv =
-      G_TYPE_INSTANCE_GET_PRIVATE (self, BT_TYPE_SETTINGS_PAGE_UI,
-      BtSettingsPageUIPrivate);
+  self->priv = bt_settings_page_ui_get_instance_private(self);
   GST_DEBUG ("!!!! self=%p", self);
   self->priv->app = bt_edit_application_new ();
 }
@@ -177,8 +176,6 @@ static void
 bt_settings_page_ui_class_init (BtSettingsPageUIClass * klass)
 {
   GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
-
-  g_type_class_add_private (klass, sizeof (BtSettingsPageUIPrivate));
 
   gobject_class->dispose = bt_settings_page_ui_dispose;
   gobject_class->finalize = bt_settings_page_ui_finalize;

--- a/src/ui/edit/signal-analysis-dialog.c
+++ b/src/ui/edit/signal-analysis-dialog.c
@@ -148,8 +148,9 @@ static GQuark bus_msg_spectrum_quark = 0;
 
 //-- the class
 
-G_DEFINE_TYPE (BtSignalAnalysisDialog, bt_signal_analysis_dialog,
-    GTK_TYPE_WINDOW);
+G_DEFINE_TYPE_WITH_CODE (BtSignalAnalysisDialog, bt_signal_analysis_dialog,
+    GTK_TYPE_WINDOW, 
+    G_ADD_PRIVATE(BtSignalAnalysisDialog));
 
 
 //-- event handler helper
@@ -1293,9 +1294,7 @@ bt_signal_analysis_dialog_init (BtSignalAnalysisDialog * self)
   guint i;
   gdouble f, inc, end;
 
-  self->priv =
-      G_TYPE_INSTANCE_GET_PRIVATE (self, BT_TYPE_SIGNAL_ANALYSIS_DIALOG,
-      BtSignalAnalysisDialogPrivate);
+  self->priv = bt_signal_analysis_dialog_get_instance_private(self);
   GST_DEBUG ("!!!! self=%p", self);
   self->priv->app = bt_edit_application_new ();
 
@@ -1335,8 +1334,6 @@ bt_signal_analysis_dialog_class_init (BtSignalAnalysisDialogClass * klass)
 
   bus_msg_level_quark = g_quark_from_static_string ("level");
   bus_msg_spectrum_quark = g_quark_from_static_string ("spectrum");
-
-  g_type_class_add_private (klass, sizeof (BtSignalAnalysisDialogPrivate));
 
   gobject_class->set_property = bt_signal_analysis_dialog_set_property;
   gobject_class->dispose = bt_signal_analysis_dialog_dispose;

--- a/src/ui/edit/tip-dialog.c
+++ b/src/ui/edit/tip-dialog.c
@@ -87,7 +87,8 @@ struct _BtTipDialogPrivate
 
 //-- the class
 
-G_DEFINE_TYPE (BtTipDialog, bt_tip_dialog, GTK_TYPE_DIALOG);
+G_DEFINE_TYPE_WITH_CODE (BtTipDialog, bt_tip_dialog, GTK_TYPE_DIALOG, 
+    G_ADD_PRIVATE(BtTipDialog));
 
 
 //-- event handler
@@ -315,9 +316,7 @@ bt_tip_dialog_dispose (GObject * object)
 static void
 bt_tip_dialog_init (BtTipDialog * self)
 {
-  self->priv =
-      G_TYPE_INSTANCE_GET_PRIVATE (self, BT_TYPE_TIP_DIALOG,
-      BtTipDialogPrivate);
+  self->priv = bt_tip_dialog_get_instance_private(self);
   GST_DEBUG ("!!!! self=%p", self);
   self->priv->app = bt_edit_application_new ();
 }
@@ -326,8 +325,6 @@ static void
 bt_tip_dialog_class_init (BtTipDialogClass * klass)
 {
   GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
-
-  g_type_class_add_private (klass, sizeof (BtTipDialogPrivate));
 
   gobject_class->dispose = bt_tip_dialog_dispose;
 }

--- a/src/ui/edit/ui-resources.c
+++ b/src/ui/edit/ui-resources.c
@@ -55,7 +55,8 @@ static BtUIResources *singleton = NULL;
 
 //-- the class
 
-G_DEFINE_TYPE (BtUIResources, bt_ui_resources, G_TYPE_OBJECT);
+G_DEFINE_TYPE_WITH_CODE (BtUIResources, bt_ui_resources, G_TYPE_OBJECT, 
+    G_ADD_PRIVATE(BtUIResources));
 
 //-- event handler
 
@@ -437,17 +438,13 @@ bt_ui_resources_constructor (GType type, guint n_construct_params,
 static void
 bt_ui_resources_init (BtUIResources * self)
 {
-  self->priv =
-      G_TYPE_INSTANCE_GET_PRIVATE (self, BT_TYPE_UI_RESOURCES,
-      BtUIResourcesPrivate);
+  self->priv = bt_ui_resources_get_instance_private(self);
 }
 
 static void
 bt_ui_resources_class_init (BtUIResourcesClass * klass)
 {
   GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
-
-  g_type_class_add_private (klass, sizeof (BtUIResourcesPrivate));
 
   gobject_class->constructor = bt_ui_resources_constructor;
   gobject_class->dispose = bt_ui_resources_dispose;

--- a/src/ui/edit/wave-list-model.c
+++ b/src/ui/edit/wave-list-model.c
@@ -52,7 +52,9 @@ static void bt_wave_list_model_tree_model_init (gpointer const g_iface,
     gpointer const iface_data);
 
 G_DEFINE_TYPE_WITH_CODE (BtWaveListModel, bt_wave_list_model,
-    G_TYPE_OBJECT, G_IMPLEMENT_INTERFACE (GTK_TYPE_TREE_MODEL,
+    G_TYPE_OBJECT,
+    G_ADD_PRIVATE(BtWaveListModel)
+    G_IMPLEMENT_INTERFACE (GTK_TYPE_TREE_MODEL,
         bt_wave_list_model_tree_model_init));
 
 //-- helper
@@ -407,9 +409,7 @@ bt_wave_list_model_finalize (GObject * object)
 static void
 bt_wave_list_model_init (BtWaveListModel * self)
 {
-  self->priv =
-      G_TYPE_INSTANCE_GET_PRIVATE (self, BT_TYPE_WAVE_LIST_MODEL,
-      BtWaveListModelPrivate);
+  self->priv = bt_wave_list_model_get_instance_private(self);
 
   self->priv->seq = g_ptr_array_sized_new (N_ROWS);
   g_ptr_array_set_size (self->priv->seq, N_ROWS);
@@ -421,8 +421,6 @@ static void
 bt_wave_list_model_class_init (BtWaveListModelClass * klass)
 {
   GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
-
-  g_type_class_add_private (klass, sizeof (BtWaveListModelPrivate));
 
   gobject_class->finalize = bt_wave_list_model_finalize;
 }

--- a/src/ui/edit/wavelevel-list-model.c
+++ b/src/ui/edit/wavelevel-list-model.c
@@ -52,7 +52,9 @@ static void bt_wavelevel_list_model_tree_model_init (gpointer const g_iface,
     gpointer const iface_data);
 
 G_DEFINE_TYPE_WITH_CODE (BtWavelevelListModel, bt_wavelevel_list_model,
-    G_TYPE_OBJECT, G_IMPLEMENT_INTERFACE (GTK_TYPE_TREE_MODEL,
+    G_TYPE_OBJECT,
+    G_ADD_PRIVATE(BtWavelevelListModel)
+    G_IMPLEMENT_INTERFACE (GTK_TYPE_TREE_MODEL,
         bt_wavelevel_list_model_tree_model_init));
 
 //-- signal handlers
@@ -405,9 +407,7 @@ bt_wavelevel_list_model_finalize (GObject * object)
 static void
 bt_wavelevel_list_model_init (BtWavelevelListModel * self)
 {
-  self->priv =
-      G_TYPE_INSTANCE_GET_PRIVATE (self, BT_TYPE_WAVELEVEL_LIST_MODEL,
-      BtWavelevelListModelPrivate);
+  self->priv = bt_wavelevel_list_model_get_instance_private(self);
 
   self->priv->seq = g_sequence_new (NULL);
   // random int to check whether an iter belongs to our model
@@ -418,8 +418,6 @@ static void
 bt_wavelevel_list_model_class_init (BtWavelevelListModelClass * klass)
 {
   GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
-
-  g_type_class_add_private (klass, sizeof (BtWavelevelListModelPrivate));
 
   gobject_class->finalize = bt_wavelevel_list_model_finalize;
 }

--- a/src/ui/edit/wire-canvas-item.c
+++ b/src/ui/edit/wire-canvas-item.c
@@ -97,7 +97,8 @@ static GQuark wire_canvas_item_quark = 0;
 
 //-- the class
 
-G_DEFINE_TYPE (BtWireCanvasItem, bt_wire_canvas_item, CLUTTER_TYPE_ACTOR);
+G_DEFINE_TYPE_WITH_CODE (BtWireCanvasItem, bt_wire_canvas_item, CLUTTER_TYPE_ACTOR, 
+    G_ADD_PRIVATE(BtWireCanvasItem));
 
 //-- prototypes
 
@@ -775,9 +776,7 @@ bt_wire_canvas_item_init (BtWireCanvasItem * self)
 {
   GtkWidget *menu_item;
 
-  self->priv =
-      G_TYPE_INSTANCE_GET_PRIVATE (self, BT_TYPE_WIRE_CANVAS_ITEM,
-      BtWireCanvasItemPrivate);
+  self->priv = bt_wire_canvas_item_get_instance_private(self);
   GST_DEBUG ("!!!! self=%p", self);
   self->priv->app = bt_edit_application_new ();
 
@@ -809,8 +808,6 @@ bt_wire_canvas_item_class_init (BtWireCanvasItemClass * klass)
   GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
 
   wire_canvas_item_quark = g_quark_from_static_string ("wire-canvas-item");
-
-  g_type_class_add_private (klass, sizeof (BtWireCanvasItemPrivate));
 
   gobject_class->constructed = bt_wire_canvas_item_constructed;
   gobject_class->set_property = bt_wire_canvas_item_set_property;


### PR DESCRIPTION
Please see: 

https://developer.gnome.org/gobject/stable/gobject-Type-Information.html#G-TYPE-INSTANCE-GET-PRIVATE:CAPS

There should be no functional difference here, just replacing the deprecated call.