### PR TITLE
Boolean (checkbox) params not setting correct default on toggle

### DIFF
--- a/src/lib/core/machine.c
+++ b/src/lib/core/machine.c
@@ -2664,6 +2664,8 @@ bt_machine_reset_parameters (const BtMachine * const self)
   for (j = 0; j < voices; j++) {
     bt_parameter_group_reset_values (self->priv->voice_param_groups[j]);
   }
+
+  bt_machine_set_param_defaults (self);
 }
 
 //-- linking

--- a/src/ui/edit/machine-properties-dialog.c
+++ b/src/ui/edit/machine-properties-dialog.c
@@ -141,6 +141,8 @@ static GQuark widget_child_quark = 0;
 static GQuark widget_param_group_quark = 0;     /* points to ParamGroup */
 static GQuark widget_param_num_quark = 0;       /* which parameter inside the group */
 
+static void update_param_after_interaction (GtkWidget * widget);
+
 //-- the class
 
 G_DEFINE_TYPE_WITH_CODE (BtMachinePropertiesDialog, bt_machine_properties_dialog,
@@ -195,7 +197,6 @@ get_param_group (const BtMachinePropertiesDialog * self, GObject * param_parent)
 static void
 on_parameter_reset (GtkMenuItem * menuitem, gpointer user_data)
 {
-  //BtMachinePropertiesDialog *self=BT_MACHINE_PROPERTIES_DIALOG(user_data);
   GtkWidget *menu;
   GObject *object;
   gchar *property_name;
@@ -215,6 +216,14 @@ on_parameter_reset (GtkMenuItem * menuitem, gpointer user_data)
     g_param_value_set_default (pspec, &gvalue);
     g_object_set_property (object, property_name, &gvalue);
     g_value_unset (&gvalue);
+
+    // The property control widget that was right-clicked on.
+	GtkWidget *actuator_widget = gtk_menu_get_attach_widget (menu);
+	if (actuator_widget) {
+	  update_param_after_interaction (actuator_widget);
+	} else {
+	  GST_ERROR("Couldn't set default value on property after reset");
+	}
   }
 
   g_object_unref (object);
@@ -595,14 +604,14 @@ on_uint64_range_property_format_value (GtkScale * scale, gdouble value,
 }
 
 static void
-update_param_after_interaction (GtkWidget * widget, gpointer user_data)
+update_param_after_interaction (GtkWidget * widget)
 {
   BtMachinePropertiesDialog *self =
       BT_MACHINE_PROPERTIES_DIALOG (g_object_get_qdata (G_OBJECT (widget),
           widget_parent_quark));
 
   bt_machine_update_default_param_value (self->priv->machine,
-      gtk_widget_get_name (GTK_WIDGET (widget)),
+      gtk_widget_get_name (widget),
       g_object_get_qdata (G_OBJECT (widget), widget_param_group_quark));
 }
 
@@ -683,8 +692,8 @@ on_button_press_event (GtkWidget * widget, GdkEventButton * event,
           "selected-parameter-group", pg, "selected-property-name",
           property_name, NULL);
 
-      gtk_menu_popup (GTK_MENU (m), NULL, NULL, NULL, NULL,
-          GDK_BUTTON_SECONDARY, gtk_get_current_event_time ());
+      gtk_menu_popup_at_pointer (GTK_MENU (m), event);
+      gtk_menu_attach_to_widget (GTK_MENU (m), widget, NULL);
       res = TRUE;
     } else if (event->button == GDK_BUTTON_PRIMARY) {
       gst_object_set_control_binding_disabled (param_parent, property_name,
@@ -700,7 +709,7 @@ on_button_release_event (GtkWidget * widget, GdkEventButton * event,
     gpointer user_data)
 {
   if (event->button == GDK_BUTTON_PRIMARY && event->type == GDK_BUTTON_RELEASE) {
-    update_param_after_interaction (widget, user_data);
+    update_param_after_interaction (widget);
   }
   return FALSE;
 }
@@ -710,7 +719,7 @@ on_key_release_event (GtkWidget * widget, GdkEventKey * event,
     gpointer user_data)
 {
   if (event->type == GDK_KEY_RELEASE) {
-    update_param_after_interaction (widget, user_data);
+    update_param_after_interaction (widget);
   }
   return FALSE;
 }
@@ -855,6 +864,7 @@ on_double_range_property_changed (GtkRange * range, gpointer user_data)
       G_SIGNAL_MATCH_FUNC | G_SIGNAL_MATCH_DATA, 0, 0, NULL,
       on_double_range_property_notify, (gpointer) range);
   g_object_set (param_parent, name, value, NULL);
+  update_param_after_interaction (GTK_WIDGET (range));
   g_signal_handlers_unblock_matched (param_parent,
       G_SIGNAL_MATCH_FUNC | G_SIGNAL_MATCH_DATA, 0, 0, NULL,
       on_double_range_property_notify, (gpointer) range);
@@ -920,6 +930,7 @@ on_float_range_property_changed (GtkRange * range, gpointer user_data)
       G_SIGNAL_MATCH_FUNC | G_SIGNAL_MATCH_DATA, 0, 0, NULL,
       on_float_range_property_notify, (gpointer) range);
   g_object_set (param_parent, name, value, NULL);
+  update_param_after_interaction (GTK_WIDGET (range));
   g_signal_handlers_unblock_matched (param_parent,
       G_SIGNAL_MATCH_FUNC | G_SIGNAL_MATCH_DATA, 0, 0, NULL,
       on_float_range_property_notify, (gpointer) range);
@@ -989,6 +1000,7 @@ on_int_range_property_changed (GtkRange * range, gpointer user_data)
       G_SIGNAL_MATCH_FUNC | G_SIGNAL_MATCH_DATA, 0, 0, NULL,
       on_int_range_property_notify, (gpointer) range);
   g_object_set (param_parent, name, (gint) value, NULL);
+  update_param_after_interaction (GTK_WIDGET (range));
   g_signal_handlers_unblock_matched (param_parent,
       G_SIGNAL_MATCH_FUNC | G_SIGNAL_MATCH_DATA, 0, 0, NULL,
       on_int_range_property_notify, (gpointer) range);
@@ -1058,6 +1070,7 @@ on_uint_range_property_changed (GtkRange * range, gpointer user_data)
       G_SIGNAL_MATCH_FUNC | G_SIGNAL_MATCH_DATA, 0, 0, NULL,
       on_uint_range_property_notify, (gpointer) range);
   g_object_set (param_parent, name, (guint) value, NULL);
+  update_param_after_interaction (GTK_WIDGET (range));
   g_signal_handlers_unblock_matched (param_parent,
       G_SIGNAL_MATCH_FUNC | G_SIGNAL_MATCH_DATA, 0, 0, NULL,
       on_uint_range_property_notify, (gpointer) range);
@@ -1182,6 +1195,7 @@ on_uint64_entry_property_changed (GtkEditable * editable, gpointer user_data)
       G_SIGNAL_MATCH_FUNC | G_SIGNAL_MATCH_DATA, 0, 0, NULL,
       on_uint64_range_property_notify, (gpointer) range);
   g_object_set (param_parent, name, clamped_value, NULL);
+  update_param_after_interaction (GTK_WIDGET (range));
   g_signal_handlers_unblock_matched (param_parent,
       G_SIGNAL_MATCH_FUNC | G_SIGNAL_MATCH_DATA, 0, 0, NULL,
       on_uint64_range_property_notify, (gpointer) range);
@@ -1258,7 +1272,7 @@ on_combobox_property_changed (GtkComboBox * combobox, gpointer user_data)
         G_SIGNAL_MATCH_FUNC | G_SIGNAL_MATCH_DATA, 0, 0, NULL,
         on_combobox_property_notify, (gpointer) combobox);
     //GST_WARNING("property value change received: %d",value);
-    update_param_after_interaction (GTK_WIDGET (combobox), user_data);
+    update_param_after_interaction (GTK_WIDGET (combobox));
     bt_edit_application_set_song_unsaved (self->priv->app);
   }
 }
@@ -1312,7 +1326,7 @@ on_checkbox_property_toggled (GtkToggleButton * togglebutton,
   g_signal_handlers_unblock_matched (param_parent,
       G_SIGNAL_MATCH_FUNC | G_SIGNAL_MATCH_DATA, 0, 0, NULL,
       on_checkbox_property_notify, (gpointer) togglebutton);
-  //update_param_after_interaction(GTK_WIDGET(togglebutton),user_data);
+  update_param_after_interaction(GTK_WIDGET(togglebutton));
   bt_edit_application_set_song_unsaved (self->priv->app);
 }
 
@@ -1622,8 +1636,6 @@ make_int_range_widget (const BtMachinePropertiesDialog * self,
       G_CALLBACK (on_int_range_property_changed), (gpointer) machine);
   g_signal_connect (widget, "button-press-event",
       G_CALLBACK (on_range_button_press_event), (gpointer) machine);
-  g_signal_connect (widget, "button-release-event",
-      G_CALLBACK (on_button_release_event), (gpointer) machine);
   g_signal_connect (widget, "key-release-event",
       G_CALLBACK (on_key_release_event), (gpointer) machine);
   return widget;
@@ -1654,8 +1666,6 @@ make_uint_range_widget (const BtMachinePropertiesDialog * self,
       G_CALLBACK (on_uint_range_property_changed), (gpointer) machine);
   g_signal_connect (widget, "button-press-event",
       G_CALLBACK (on_range_button_press_event), (gpointer) machine);
-  g_signal_connect (widget, "button-release-event",
-      G_CALLBACK (on_button_release_event), (gpointer) machine);
   g_signal_connect (widget, "key-release-event",
       G_CALLBACK (on_key_release_event), (gpointer) machine);
   return widget;
@@ -1686,8 +1696,6 @@ make_uint64_range_widget (const BtMachinePropertiesDialog * self,
       G_CALLBACK (on_uint64_range_property_changed), (gpointer) machine);
   g_signal_connect (widget, "button-press-event",
       G_CALLBACK (on_range_button_press_event), (gpointer) machine);
-  g_signal_connect (widget, "button-release-event",
-      G_CALLBACK (on_button_release_event), (gpointer) machine);
   g_signal_connect (widget, "key-release-event",
       G_CALLBACK (on_key_release_event), (gpointer) machine);
   g_signal_connect (entry, "changed",
@@ -1723,8 +1731,6 @@ make_float_range_widget (const BtMachinePropertiesDialog * self,
       G_CALLBACK (on_float_range_property_changed), (gpointer) machine);
   g_signal_connect (widget, "button-press-event",
       G_CALLBACK (on_range_button_press_event), (gpointer) machine);
-  g_signal_connect (widget, "button-release-event",
-      G_CALLBACK (on_button_release_event), (gpointer) machine);
   g_signal_connect (widget, "key-release-event",
       G_CALLBACK (on_key_release_event), (gpointer) machine);
   return widget;
@@ -1758,8 +1764,6 @@ make_double_range_widget (const BtMachinePropertiesDialog * self,
       G_CALLBACK (on_double_range_property_changed), (gpointer) machine);
   g_signal_connect (widget, "button-press-event",
       G_CALLBACK (on_range_button_press_event), (gpointer) machine);
-  g_signal_connect (widget, "button-release-event",
-      G_CALLBACK (on_button_release_event), (gpointer) machine);
   g_signal_connect (widget, "key-release-event",
       G_CALLBACK (on_key_release_event), (gpointer) machine);
   return widget;
@@ -1855,8 +1859,6 @@ make_checkbox_widget (const BtMachinePropertiesDialog * self, GObject * machine,
       G_CALLBACK (on_checkbox_property_toggled), (gpointer) machine);
   g_signal_connect (widget, "button-press-event",
       G_CALLBACK (on_trigger_button_press_event), (gpointer) machine);
-  g_signal_connect (widget, "button-release-event",
-      G_CALLBACK (on_button_release_event), (gpointer) machine);
   g_signal_connect (widget, "key-release-event",
       G_CALLBACK (on_key_release_event), (gpointer) machine);
   return widget;


### PR DESCRIPTION
This one is more for discussion at this stage, I just made a pull request so you can easily see the code changes.

I play a lot with Buzztrax in looping mode while I fiddle with parameters, and I've seen a few issues with parameters flipping back to old values (or in this case, values from two changes ago) when the song loops. Generally, the value's "pattern default" will not have been set properly at some point during the UI event. The issue here was seen when toggling a boolean property (checkbox.)

"update_param_after_interaction" is the call that sets the pattern default, according to the current property value. 

"on_checkbox_property_toggled" via the "toggled" signal is the code that actually updates the property on the object, but "on_button_release_event" via "button-release-event" is called first, and it seems that the object's property hasn't been set yet, so the wrong "default" is set for the property.

Making the changes below did fix the problem, but I'm not really sure of the "right" fix.