### PR TITLE
Crude custom graphics for machine elements

### DIFF
--- a/Makefile.src.am
+++ b/Makefile.src.am
@@ -217,6 +217,7 @@ libbuzztrax_gst_la_SOURCES = \
   src/lib/gst/toneconversion.c \
   src/lib/gst/propertymeta.c \
   src/lib/gst/tempo.c \
+  src/lib/gst/ui.c \
   $(GST_COMPAT_C_FILES)
 
 libbuzztrax_gstincludedir = $(includedir)/libbuzztrax-gst
@@ -236,6 +237,7 @@ libbuzztrax_gstinclude_HEADERS = \
   src/lib/gst/toneconversion.h \
   src/lib/gst/propertymeta.h \
   src/lib/gst/tempo.h \
+  src/lib/gst/ui.h \
   $(GST_COMPAT_H_FILES)
 
 presetdir = $(datadir)/gstreamer-$(GST_MAJORMINOR)/presets

--- a/src/lib/gst/ui.c
+++ b/src/lib/gst/ui.c
@@ -1,0 +1,67 @@
+/* Buzztrax
+ * Copyright (C) 2022 David Beswick <dlbeswick@gmail.com>
+ *
+ * lib/gst/ui.c: relating to UI functions of plugin machines.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+/**
+ * SECTION:ui
+ * @title: GstBtUiCustomGfxInterface
+ * @include: libtbuzztrax-gst/ui.h
+ * @short_description: custom gfx in machine view
+ *
+ * Allows a machine to supply its own graphics to be drawn over the machine in
+ * the Machine View.
+ *
+ * SIGNALS:
+ *
+ * gstbt-ui-gfx-invalidated() [G_SIGNAL_ACTION]
+ * 
+ * Machines generally don't have to do anything in response to this signal, but
+ * they should emit it when something happens that should change the image,
+ * i.e. by the machine on a parameter change.
+ */
+
+#include "ui.h"
+
+G_DEFINE_INTERFACE(GstBtUiCustomGfx, gstbt_ui_custom_gfx, G_TYPE_OBJECT)
+
+static void gstbt_ui_custom_gfx_default_init (GstBtUiCustomGfxInterface *iface) {
+  g_signal_new (
+    "gstbt-ui-custom-gfx-invalidated",
+    G_OBJECT_CLASS_TYPE(iface),
+    G_SIGNAL_ACTION | G_SIGNAL_RUN_LAST,
+    0 /* offset */,
+    NULL /* accumulator */,
+    NULL /* accumulator data */,
+    NULL /* C marshaller */,
+    G_TYPE_NONE /* return_type */,
+    0     /* n_params */);
+}
+
+const GstBtUiCustomGfxResponse* gstbt_ui_custom_gfx_request (GstBtUiCustomGfx *self) {
+  GstBtUiCustomGfxInterface *iface;
+
+  g_return_val_if_fail (GSTBT_UI_IS_CUSTOM_GFX (self), 0);
+
+  iface = GSTBT_UI_CUSTOM_GFX_GET_IFACE (self);
+  g_return_val_if_fail (iface->request != NULL, 0);
+  return iface->request (self);
+}

--- a/src/lib/gst/ui.h
+++ b/src/lib/gst/ui.h
@@ -1,0 +1,68 @@
+/* Buzztrax
+ * Copyright (C) 2022 David Beswick <dlbeswick@gmail.com>
+ *
+ * lib/gst/ui.h: relating to UI functions of plugin machines.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef __LIB_GST_UI_H__
+#define __LIB_GST_UI_H__
+
+#include <glib-object.h>
+
+G_BEGIN_DECLS
+
+/**
+ * GstBtUiCustomGfxResponse: returned by GstBtUiCustomGfxInterface::request
+ *
+ * @version: set to 0
+ * @width: width of returned image in pixels
+ * @height: height of returned image in pixels
+ * @data: ABGR data, width*height guints
+ */
+typedef struct GstBtUiCustomGfxResponse {
+  guint version; // set to 0
+  guint width;
+  guint height;
+  guint32* data;   // ABGR data, width*height guints
+} GstBtUiCustomGfxResponse;
+
+
+#define GSTBT_UI_TYPE_CUSTOM_GFX gstbt_ui_custom_gfx_get_type ()
+G_DECLARE_INTERFACE (GstBtUiCustomGfx, gstbt_ui_custom_gfx, GSTBT_UI, CUSTOM_GFX,
+                     GObject)
+
+/**
+ * GstBtUiCustomGfxInterface
+ *
+ * @request: Return the machine's current custom gfx image.
+ *           Ownership of the returned object isn't transferred, so cached data
+ *           can be used (both response structure and image data.)
+ *
+ *           The actual rendering of the image may be done here.
+ *
+ *           May return NULL; in that case, Buzztrax's standard gfx are used.
+*/
+struct _GstBtUiCustomGfxInterface {
+  GTypeInterface parent;
+
+  const GstBtUiCustomGfxResponse *(*request) (GstBtUiCustomGfx *self);
+};
+
+const GstBtUiCustomGfxResponse *gstbt_ui_custom_gfx_request (GstBtUiCustomGfx *self);
+
+G_END_DECLS
+
+#endif

--- a/src/ui/edit/machine-canvas-item.c
+++ b/src/ui/edit/machine-canvas-item.c
@@ -70,6 +70,7 @@
 #define BT_MACHINE_CANVAS_ITEM_C
 
 #include "bt-edit.h"
+#include "src/lib/gst/ui.h"
 
 #define LOW_VUMETER_VAL -60.0
 
@@ -124,6 +125,7 @@ struct _BtMachineCanvasItemPrivate
 
   /* the graphical components */
   ClutterContent *image;
+  ClutterContent *image_custom_gfx;
   ClutterActor *label;
   ClutterActor *output_meter, *input_meter;
   GstElement *output_level;
@@ -147,6 +149,10 @@ struct _BtMachineCanvasItemPrivate
   /* playback state */
   gboolean is_playing;
 
+  /* custom graphics */
+  guint custom_gfx_timer;
+  GMutex custom_gfx_lock;
+  
   /* lock for multithreaded access */
   GMutex lock;
 };
@@ -192,6 +198,65 @@ update_machine_graphics (BtMachineCanvasItem * self)
       gdk_pixbuf_get_height (pixbuf));
 
   g_object_unref (pixbuf);
+}
+
+static void
+update_custom_graphics (BtMachineCanvasItem * self, guint width, guint height, guint32 * data) {
+  g_return_if_fail(self->priv->image_custom_gfx);
+
+  if (data) {
+    clutter_image_set_data (CLUTTER_IMAGE (self->priv->image_custom_gfx),
+        (guint8*)data, COGL_PIXEL_FORMAT_RGBA_8888, width, height, width*4, NULL);
+  } else {
+    int32_t zero = 0;
+    clutter_image_set_data (CLUTTER_IMAGE (self->priv->image_custom_gfx),
+        (guint8*)&zero, COGL_PIXEL_FORMAT_RGBA_8888, 1, 1, 4, NULL);
+  }
+}
+
+static gboolean
+custom_gfx_request_after_invalidation (BtMachineCanvasItem * self) {
+  GstElement *element;
+  g_object_get (self->priv->machine, "machine", &element, NULL);
+
+  const GstBtUiCustomGfxResponse* gfx_response = 0;
+  if (GSTBT_UI_IS_CUSTOM_GFX (element)) {
+    gfx_response = gstbt_ui_custom_gfx_request(GSTBT_UI_CUSTOM_GFX (element));
+  }
+  
+  if (gfx_response) {
+    update_custom_graphics (self, gfx_response->width, gfx_response->height,
+                            gfx_response->data);
+  } else {
+    update_custom_graphics (self, 0, 0, NULL);
+  }
+
+  g_clear_object (&element);
+          
+  g_mutex_lock (&self->priv->custom_gfx_lock);
+  self->priv->custom_gfx_timer = 0;
+  g_mutex_unlock (&self->priv->custom_gfx_lock);
+  return FALSE;
+}
+
+static void
+on_custom_gfx_invalidated (BtMachine * machine, BtMachineCanvasItem * self) {
+  // Updating the custom gfx this way is important for two reasons:
+  //
+  // 1. It makes sure that the image update happens on the main thread.
+  //    Clutter doesn't seem to like requests coming from another thread.
+  //    This will likely be called from the Gstreaming processing thread.
+  // 2. It aggregates many invalidating requests that might happen on a
+  //    single frame (i.e. from multiple machine property updates) into a
+  //    single "update gfx" call.
+  g_mutex_lock(&self->priv->custom_gfx_lock);
+  if (!self->priv->custom_gfx_timer) {
+    // Set a timer for 16 ms, limit the updates to ~60 fps.
+    self->priv->custom_gfx_timer =
+        g_timeout_add(16, G_SOURCE_FUNC(custom_gfx_request_after_invalidation),
+            self);
+  }
+  g_mutex_unlock(&self->priv->custom_gfx_lock);
 }
 
 static void
@@ -1074,6 +1139,14 @@ bt_machine_canvas_item_constructed (GObject * object)
       (MACHINE_H / -2.0), 0.0);
   clutter_actor_set_content ((ClutterActor *) self, self->priv->image);
 
+  // a child actor allowing display of additional gfx by the machine element
+  ClutterActor *actor_custom_gfx = clutter_actor_new();
+  clutter_actor_set_content_scaling_filters (actor_custom_gfx,
+      CLUTTER_SCALING_FILTER_TRILINEAR, CLUTTER_SCALING_FILTER_LINEAR);
+  clutter_actor_set_size (actor_custom_gfx, MACHINE_W, MACHINE_H);
+  clutter_actor_set_content (actor_custom_gfx, self->priv->image_custom_gfx);
+  clutter_actor_add_child ((ClutterActor *) self, actor_custom_gfx);
+
   // the name label
   // TODO(ensonic): use MACHINE_LABEL_HEIGHT (7)
   // TODO(ensonic): when zooming, the font gets blurry :/
@@ -1202,6 +1275,14 @@ bt_machine_canvas_item_set_property (GObject * object, guint property_id,
       if (new_machine != self->priv->machine) {
         GstElement *element;
 
+        if (self->priv->machine) {
+          GstElement *element_old;
+          g_object_get (self->priv->machine, "machine", &element_old, NULL);
+          g_signal_handlers_disconnect_by_func (
+              element_old, on_custom_gfx_invalidated, (gpointer) self);
+          g_object_unref(element_old);
+        }
+        
         g_object_try_unref (self->priv->machine);
         self->priv->machine = g_object_ref (new_machine);
 
@@ -1211,6 +1292,16 @@ bt_machine_canvas_item_set_property (GObject * object, guint property_id,
             machine_canvas_item_quark, (gpointer) self);
         g_object_get (self->priv->machine, "properties",
             &self->priv->properties, "machine", &element, NULL);
+
+        // connect to custom gfx signal event, if available
+        if (GSTBT_UI_IS_CUSTOM_GFX (element)) {
+          g_signal_connect (element, "gstbt-ui-custom-gfx-invalidated",
+              G_CALLBACK (on_custom_gfx_invalidated), self);
+
+          // ask the element to send an image based on its current state, so the
+          // image will have data from the start
+          g_signal_emit_by_name (element, "gstbt-ui-custom-gfx-invalidated");
+        }
 
         self->priv->help_uri =
             gst_element_factory_get_metadata (gst_element_get_factory (element),
@@ -1275,7 +1366,16 @@ bt_machine_canvas_item_dispose (GObject * object)
   GST_DEBUG ("machine: %" G_OBJECT_REF_COUNT_FMT,
       G_OBJECT_LOG_REF_COUNT (self->priv->machine));
 
+  if (self->priv->machine) {
+    GstElement *element_old;
+    g_object_get (self->priv->machine, "machine", &element_old, NULL);
+    g_signal_handlers_disconnect_by_func (
+      element_old, on_custom_gfx_invalidated, (gpointer) self);
+    g_object_unref(element_old);
+  }
+  
   g_object_unref (self->priv->image);
+  g_object_unref (self->priv->image_custom_gfx);
 
   GST_INFO ("release the machine %" G_OBJECT_REF_COUNT_FMT,
       G_OBJECT_LOG_REF_COUNT (self->priv->machine));
@@ -1318,6 +1418,7 @@ bt_machine_canvas_item_finalize (GObject * object)
 
   GST_DEBUG ("!!!! self=%p", self);
   g_mutex_clear (&self->priv->lock);
+  g_mutex_clear (&self->priv->custom_gfx_lock);
 
   G_OBJECT_CLASS (bt_machine_canvas_item_parent_class)->finalize (object);
   GST_DEBUG ("  done");
@@ -1571,6 +1672,11 @@ bt_machine_canvas_item_init (BtMachineCanvasItem * self)
   self->priv->zoom = 1.0;
 
   g_mutex_init (&self->priv->lock);
+  g_mutex_init (&self->priv->custom_gfx_lock);
+
+  self->priv->image_custom_gfx = clutter_image_new ();
+
+  update_custom_graphics (self, 0, 0, NULL);
 }
 
 static void


### PR DESCRIPTION
See the graphics drawn on the "kick" and "distort" machines below:

![Screenshot from 2021-06-19 23-41-47-1](https://user-images.githubusercontent.com/907688/122644315-f5bb8800-d157-11eb-9a05-e9bf6c5f3f2a.png)

I wanted to be able to visualise things like my distort function and my kick's volume envelope, so I added this in. Very open to discussion on this, it's ugly and more of a starting point. For example, maybe this could be shown via a "drawer" the pops open at the bottom of the machine, rather than drawing over the standard gfx.

This signal-based approach might also point the way to things such as machine-specific formatting of parameter values, like Buzz used to have. I'm conscious of trying to avoid hard dependencies between the UI and machine.

Have a look here to see it in action in a machine: https://github.com/dlbeswick/bt-edp-distort/blob/master/src/machine.c

It works via three signals:

1. Either the UI or machine can emit "bt-gfx-invalidated" to ask for a redraw. The machine will emit this when parameters change, for instance.
1. The UI connects to "bt-gfx-invalidated" and will shortly afterwards emit "bt-gfx-request" to the machine, to ask for the graphics.
1. The machine in response will draw an ABGR image and emit "bt-gfx-present" back to the UI, passing the width, height and image data.

This could be pared down to two signals if I could figure out the best way to pass the width, height and image data as a return value from "bt-gfx-request". Struct? GObject? I don't want to have to link with any UI/edit-specific data structures, although headers are obviously ok.

It's important to make sure the image gets set in the main thread, and a glib timer is used to do this. The "invalidate" logic is also used so that many property updates (i.e. when the song starts) only resolve to a single gfx update call.