### PR TITLE
Fixed sequence patterns being lost when setting song end

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -74,6 +74,11 @@ AC_DEFINE_UNQUOTED(BT_RELEASE_YEAR, $BT_RELEASE_YEAR, [release year])
 
 dnl Checks for programs.
 AC_PROG_CC
+AC_PROG_CC_C99
+if test "x$ac_cv_prog_cc_c99" = "no" ; then
+	AC_MSG_ERROR([C compiler seems not to support required C99 features.])
+fi
+
 AC_PROG_CPP
 AC_PROG_CXX
 AC_PROG_INSTALL

--- a/src/ui/edit/main-page-sequence.c
+++ b/src/ui/edit/main-page-sequence.c
@@ -1921,7 +1921,7 @@ sequence_set_loop_end (const BtMainPageSequence * self, glong row)
 
     // we shorten the song, backup data
     if (row < sequence_length) {
-      GString *old_data = g_string_new (NULL);
+      /*GString *old_data = g_string_new (NULL);
       gulong number_of_tracks;
 
       g_object_get (self->priv->sequence, "tracks", &number_of_tracks, NULL);
@@ -1929,7 +1929,7 @@ sequence_set_loop_end (const BtMainPageSequence * self, glong row)
           sequence_length - 1, old_data);
       sequence_range_log_undo_redo (self, 0, number_of_tracks, row,
           sequence_length - 1, old_data->str, g_strdup (old_data->str));
-      g_string_free (old_data, TRUE);
+          g_string_free (old_data, TRUE);*/
     }
     bt_change_log_end_group (self->priv->change_log);
 

--- a/src/ui/edit/sequence-grid-model.c
+++ b/src/ui/edit/sequence-grid-model.c
@@ -265,7 +265,7 @@ on_sequence_length_changed (BtSequence * sequence, GParamSpec * arg,
   BtSequenceGridModel *model = BT_SEQUENCE_GRID_MODEL (user_data);
   gulong old_length = model->priv->length;
 
-  g_object_get ((gpointer) sequence, "length", &model->priv->length, NULL);
+  g_object_get ((gpointer) sequence, "len-patterns", &model->priv->length, NULL);
   if (model->priv->length != old_length) {
     gulong old_visible_length = model->priv->visible_length;
     model->priv->visible_length = MAX (old_visible_length, model->priv->length);


### PR DESCRIPTION
When the "song end" was set, patterns were lost and even undo didn't retrieve them. If you accidentally set the end of the song at tick 0, then the whole song was lost.

I also changed the behaviour here; the sequence is no longer truncated when setting the end point earlier in the song.

The sequence is only truncated up to the point where only empty patterns are in the sequence. This behaviour matches Buzz and I think it's kinder to users, too.