### PR TITLE
Make sure any patterns beyond the song "end" are saved and restored.

### DIFF
--- a/src/ui/edit/main-page-sequence.c
+++ b/src/ui/edit/main-page-sequence.c
@@ -3500,7 +3500,7 @@ on_song_changed (const BtEditApplication * app, GParamSpec * arg,
 
   g_object_get (song, "setup", &setup, "song-info", &self->priv->song_info,
       "sequence", &self->priv->sequence, "bin", &bin, NULL);
-  g_object_get (self->priv->sequence, "length", &sequence_length, "properties",
+  g_object_get (self->priv->sequence, "len-patterns", &sequence_length, "properties",
       &self->priv->properties, NULL);
   // make sequence_length and step_filter_pos accord to song length
   self->priv->sequence_length = sequence_length;


### PR DESCRIPTION
This is a second part to my recent pull request fixing the ability to set the song "end" while not truncating any patterns.

On saving and loading, any patterns beyond the end of "length" were still truncated; this fixes it.

Also I think there was an error in `dispose`: `self->priv->length` was used to free patterns instead of `self->priv->len_patterns`. It probably wasn't leaking in the past because by the time `dispose` was called these two values would have always been the same, but this isn't the case any more.

`bt_sequence_persistence_load` starts to get a bit messy, sorry. In the long run we need to separate out the shared logic that needs to happen both when self->priv->length is set internally and set by clients. IMO we should avoid setting gobject props during serialization for this reason; typically we should set the variables directly and then manually call any logic required after setting, organising the logic to be shared with setters as appropriate. Even if gobject prop setter logic is simple now, it might not be in future, which can lead to bugs.

Thanks!