### PR TITLE
Update tests for "check" v0.15.2 + fixes

### DIFF
--- a/Makefile.tests.am
+++ b/Makefile.tests.am
@@ -402,8 +402,12 @@ test-clean-local:
 	fi;
 
 # make check           -- run all checks
-# make (test).check    -- run the given check once
-#	make (test).check BT_CHECKS="test5*" -- run the given testcase(s) only
+#
+# make (test).check    -- run the given check once (i.e. "make bt_core.check", "make bt_ic.check")
+# I.e. make bt_core.check
+#      make bt_ic.check
+#
+# make (test).check BT_CHECKS="test5*" -- run the given testcase(s) only
 %.check: %
 	@$(AM_TESTS_ENVIRONMENT)	\
 	./$*

--- a/Makefile.tests.am
+++ b/Makefile.tests.am
@@ -37,7 +37,7 @@ CHECK_REGISTRY = $(top_builddir)/tests/test-registry.reg
 # for gtk/x11 issues
 #    GDK_SYNCHRONIZE=1
 #
-AM_TESTS_ENVIRONMENT = \
+AM_TESTS_ENVIRONMENT_VARS = \
 	CK_DEFAULT_TIMEOUT=20 \
 	LANG=C \
 	XDG_CACHE_HOME=$(abs_top_builddir) \
@@ -49,8 +49,10 @@ AM_TESTS_ENVIRONMENT = \
 	GST_REGISTRY_1_0=$(CHECK_REGISTRY) \
 	GST_PLUGIN_SYSTEM_PATH_1_0= \
 	GST_PLUGIN_PATH_1_0=$(abs_top_builddir)/.libs:$(GST_PLUGINS_DIR) \
-	BML_PATH=$(top_builddir)/.libs \
-	$(LIBTOOL) --mode=execute
+	BML_PATH=$(top_builddir)/.libs
+
+AM_TESTS_ENVIRONMENT = \
+	$(AM_TESTS_ENVIRONMENT_VARS) $(LIBTOOL) --mode=execute
 
 # This should make the icon theme look here for icons too, but instead it breaks tons of things
 #	XDG_DATA_DIRS=$XDG_DATA_DIRS:$(abs_top_srcdir)
@@ -516,17 +518,17 @@ if USE_VALGRIND
 # LIBOVERLAY_SCROLLBAR=0
 
 VALPREFIX = \
+	$(AM_TESTS_ENVIRONMENT_VARS) \
 	CK_FORK=no CK_DEFAULT_TIMEOUT=500 \
-	LANG=C XDG_CACHE_HOME=$(abs_builddir) \
 	G_SLICE=always-malloc G_DEBUG=gc-friendly \
 	GLIBCPP_FORCE_NEW=1 GLIBCXX_FORCE_NEW=1
 VALDEFAULT = @VALGRIND@/bin/valgrind
 VALSUPP = @VALGRIND@/lib/x86_64-linux-gnu/valgrind
 VALSUPPRESSIONDEF = --suppressions=$(VALSUPP)/default.supp
-VALSUPPRESSIONOWN = --suppressions=$(top_builddir)/buzztrax.supp \
-	--suppressions=$(top_builddir)/gst.supp \
-	--suppressions=$(top_builddir)/gtk.supp \
-	--suppressions=$(top_builddir)/clutter.supp
+VALSUPPRESSIONOWN = --suppressions=$(top_srcdir)/buzztrax.supp \
+	--suppressions=$(top_srcdir)/gst.supp \
+	--suppressions=$(top_srcdir)/gtk.supp \
+	--suppressions=$(top_srcdir)/clutter.supp
 VALSUPPRESSION = $(VALSUPPRESSIONDEF) $(VALSUPPRESSIONOWN)
 VALOPTIONS = --trace-children=yes --num-callers=30 --read-var-info=yes \
   --tool=memcheck --leak-check=full --leak-resolution=high --track-origins=yes

--- a/README.md
+++ b/README.md
@@ -107,3 +107,17 @@ activate some logging info that can help while testing:
     BT_TEST_DEBUG=1 make check
 
 The tests make use of Xvfb (X Virtual Frame Buffer) to create UI in a headless scenario; if installed, it will be used. Sometimes it's useful to be able to see the UI when writing or debugging tests, though. You can set `BT_CHECK_NO_XVFB=1` to disable use of XVfb. You will then see UI windows created on your desktop directly during test runs.
+
+To debug a test with gdb, try:
+
+    BT_CHECKS="test_bt_edit_app*" make bt_edit.gdb
+
+To run Valgrind's memcheck over the test:
+
+    BT_CHECKS="test_bt_edit_app*" make bt_edit.valgrind
+    
+The Valgrind log file will be found at /tmp/<test_name>.valgrind.<pid>. Logs without errors are deleted automatically after test execution.
+
+You may find that you need to tweak the location of the Valgrind suppression files for your OS (the 'default.supp' file is found there.) If you have that issue, try this:
+
+    VALSUPP=/usr/libexec/valgrind BT_CHECKS="test_bt_edit_app*" make -e bt_edit.valgrind

--- a/README.md
+++ b/README.md
@@ -98,8 +98,17 @@ run all the tests:
 
     make check
 
+run all the tests in one suite:
+
+    make bt_cmd.check
+    make bt_core.check
+    make bt_edit.check
+    make bt_gst.check
+    make bt_ic.check
+
 select tests to run:
 
+    BT_CHECKS="test_bt_edit_app*" make check
     BT_CHECKS="test_bt_edit_app*" make bt_edit.check
     
 activate some logging info that can help while testing:
@@ -108,11 +117,11 @@ activate some logging info that can help while testing:
 
 The tests make use of Xvfb (X Virtual Frame Buffer) to create UI in a headless scenario; if installed, it will be used. Sometimes it's useful to be able to see the UI when writing or debugging tests, though. You can set `BT_CHECK_NO_XVFB=1` to disable use of XVfb. You will then see UI windows created on your desktop directly during test runs.
 
-To debug a test with gdb, try:
+To debug a test suite with gdb, try:
 
     BT_CHECKS="test_bt_edit_app*" make bt_edit.gdb
 
-To run Valgrind's memcheck over the test:
+To run Valgrind's memcheck over a test suite:
 
     BT_CHECKS="test_bt_edit_app*" make bt_edit.valgrind
     

--- a/docs/help/bt-edit/C/Makefile.am
+++ b/docs/help/bt-edit/C/Makefile.am
@@ -7,7 +7,7 @@ buzztrax-edit.pdf: index.docbook dblatex_pdf.xsl
 	  -I figures \
 	  index.docbook
 
-buzztrax-edit.txt: index.docbook
+buzztrax-edit.txt: $(top_srcdir)/index.docbook
 	xmlto txt buzztrax-edit.xml
 
 # statistics for index building:

--- a/docs/help/bt-edit/Makefile.am
+++ b/docs/help/bt-edit/Makefile.am
@@ -14,11 +14,10 @@ HELP_LINGUAS =
 
 DOC_MODULE = legal
 
-C/version.entities: $(abs_top_builddir)/docs/version.entities
-	mkdir -p C/
+version.entities: $(abs_top_builddir)/docs/version.entities
 	@cp $< $@
 
-CLEANFILES = C/version.entities
+CLEANFILES = version.entities
 
 EXTRA_DIST = C/aspell.pws
 

--- a/src/lib/core/machine.c
+++ b/src/lib/core/machine.c
@@ -723,6 +723,10 @@ bt_machine_resize_voices (const BtMachine * const self, const gulong old_voices)
       (BtParameterGroup **) g_renew (gpointer, self->priv->voice_param_groups,
       new_voices);
   if (old_voices < new_voices) {
+    // Voices with zero parameters don't make sense, so something has gone wrong
+    // prior to this point.
+    g_assert (voice_params != 0);
+    
     GObject *voice_child;
     gulong v;
 
@@ -1421,6 +1425,14 @@ bt_machine_init_voice_params (const BtMachine * const self)
       g_object_unref (voice_child);
     } else {
       GST_WARNING_OBJECT (self, "  can't get first voice child!");
+
+      // This condition will currently lead to segfaults later on, so the program
+      // should try to avoid getting to this point (i.e. by always ensuring a
+      // minimum number of voices.
+      //
+      // Currently, machine authors should ensure that at least one voice is
+      // available immediately after their machine subclass' init function has run.
+      g_assert (FALSE);
     }
   } else {
     GST_INFO ("  instance is monophonic!");

--- a/src/lib/core/persistence.c
+++ b/src/lib/core/persistence.c
@@ -178,7 +178,7 @@ bt_persistence_load_hashtable (GHashTable * hashtable, xmlNodePtr node)
  *
  * Serializes the given object into an xmlNode.
  *
- * Returns: the new node if the object has been serialized, else %NULL.
+ * Returns: (skip): the new node if the object has been serialized, else %NULL.
  */
 xmlNodePtr
 bt_persistence_save (const BtPersistence * const self,

--- a/src/lib/core/sequence.c
+++ b/src/lib/core/sequence.c
@@ -339,7 +339,16 @@ bt_sequence_get_machine_unchecked (const BtSequence * const self,
  * Return the length of the sequence minus any trailing rows that are totally
  * null/empty. Includes all available patterns, even those beyond the "end"
  * of the song.
- * 
+ *
+ * dbeswick: This function will be called whenever the sequence length is set,
+ * as part of https://github.com/Buzztrax/buzztrax/pull/109.
+ * It counts down from the max sequence length to try to find the last non-null
+ * pattern. This takes a long time if you happen to actually want a sequence that
+ * large, and tests were timing out, so I limited the max sequence size to 2**31.
+ *
+ * There are smarter ways to deal with this, but in the meantime I figure 2**31
+ * should be enough for anyone?
+ *
  * Returns 0 if all rows are null or sequence length is zero.
  */
 static gulong
@@ -1933,9 +1942,12 @@ bt_sequence_class_init (BtSequenceClass * const klass)
           G_PARAM_CONSTRUCT_ONLY | G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 
   // loop-pos are LONG as well
+  //
+  // The max value here was previously G_MAXULONG. Please see the docs for 
+  // "bt_sequence_get_nonnull_length" for the reason it was changed.
   g_object_class_install_property (gobject_class, SEQUENCE_LENGTH,
       g_param_spec_ulong ("length", "length prop",
-          "length of the sequence in timeline bars", 0, G_MAXLONG, 0,
+          "length of the sequence in timeline bars", 0, G_MAXINT, 0,
           G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 
   g_object_class_install_property (gobject_class, SEQUENCE_LEN_PATTERNS,

--- a/src/lib/core/song-io-native-xml.c
+++ b/src/lib/core/song-io-native-xml.c
@@ -122,7 +122,7 @@ bt_song_io_native_xml_save (gconstpointer const _self,
         gpointer data;
 
         xmlDocDumpMemory (song_doc, &mem, (int *) &len);
-        data = g_memdup (mem, len);
+        data = g_memdup2 (mem, len);
         xmlFree (mem);
         g_object_set ((gpointer) self, "data", data, "data-len", len, NULL);
       }

--- a/tests/bt-check-ui.c
+++ b/tests/bt-check-ui.c
@@ -561,7 +561,7 @@ check_make_widget_screenshot_with_highlight (GtkWidget * widget,
   gfloat cx = 0.0, cy = 0.0;
   gfloat f = 0.75;
   gint num = 1;
-  gchar num_str[5];
+  gchar num_str[11];
   gboolean have_space;
 
   g_return_if_fail (GTK_IS_WIDGET (widget));

--- a/tests/bt-check.c
+++ b/tests/bt-check.c
@@ -602,9 +602,7 @@ _bt_check_run_test_func (const gchar * func_name)
 
   /* only run specified functions, regexps would be nice */
   for (f = funcs; f != NULL && *f != NULL; ++f) {
-    g_warning("BT_CHECK_RUN_TEST_FUNC %s == %s", *f, func_name);
     if (g_pattern_match_simple (*f, func_name)) {
-      g_warning("MATCH");
       return TRUE;
     }
   }

--- a/tests/bt-check.c
+++ b/tests/bt-check.c
@@ -602,7 +602,9 @@ _bt_check_run_test_func (const gchar * func_name)
 
   /* only run specified functions, regexps would be nice */
   for (f = funcs; f != NULL && *f != NULL; ++f) {
+    g_warning("BT_CHECK_RUN_TEST_FUNC %s == %s", *f, func_name);
     if (g_pattern_match_simple (*f, func_name)) {
+      g_warning("MATCH");
       return TRUE;
     }
   }

--- a/tests/bt-check.c
+++ b/tests/bt-check.c
@@ -1149,7 +1149,7 @@ check_readwrite_property (GParamSpec * paramspec, GObject * toCheck)
   return ret;
 }
 
-/* test gobject properties
+/* check_gobject_properties
  * @toCheck: the object to examine
  *
  * The function runs tests against all registered properties of the given
@@ -1162,7 +1162,6 @@ check_readwrite_property (GParamSpec * paramspec, GObject * toCheck)
  * - test more type
  * - use test more often :)
  */
-
 gboolean
 check_gobject_properties (GObject * toCheck)
 {

--- a/tests/bt-check.h
+++ b/tests/bt-check.h
@@ -305,9 +305,10 @@ gpointer check_gobject_get_ptr_property(gpointer obj, const gchar *prop);
 #define ck_assert_gobject_object_eq(O, X, Y) _ck_assert_gobject(O, X, ==, Y)
 #define ck_assert_gobject_object_ne(O, X, Y) _ck_assert_gobject(O, X, !=, Y)
 
+// Note: check for NULL below is only to silence GCC "%s format specifier is NULL" warning.
 #define _ck_assert_str_and_free(F, X, C, Y) do { \
   gchar *__ck = (X); \
-  ck_assert_msg(F(__ck, (Y)), "Assertion '"#X#C#Y"' failed: "#X"==\"%s\", "#Y"==\"%s\"", __ck, Y); \
+  ck_assert_msg(F(__ck, (Y)), "Assertion '"#X#C#Y"' failed: "#X"==\"%s\", "#Y"==\"%s\"", __ck, (Y) == NULL ? "" : Y); \
   g_free(__ck); \
 } while(0)
 #define ck_assert_str_eq_and_free(X, Y) _ck_assert_str_and_free(!g_strcmp0, X, ==, Y)

--- a/tests/btic-test-device.c
+++ b/tests/btic-test-device.c
@@ -48,7 +48,8 @@ static void btic_test_device_interface_init (gpointer const g_iface,
     gpointer const iface_data);
 
 G_DEFINE_TYPE_WITH_CODE (BtIcTestDevice, btic_test_device, BTIC_TYPE_DEVICE,
-    G_IMPLEMENT_INTERFACE (BTIC_TYPE_LEARN, btic_test_device_interface_init));
+    G_IMPLEMENT_INTERFACE (BTIC_TYPE_LEARN, btic_test_device_interface_init)
+    G_ADD_PRIVATE (BtIcTestDevice));
 
 //-- constructor methods
 
@@ -201,9 +202,7 @@ btic_test_device_init (BtIcTestDevice * self)
 {
   guint ix = 0;
 
-  self->priv =
-      G_TYPE_INSTANCE_GET_PRIVATE (self, BTIC_TYPE_TEST_DEVICE,
-      BtIcTestDevicePrivate);
+  self->priv = btic_test_device_get_instance_private (self);
 
   // register some static controls
   btic_abs_range_control_new (BTIC_DEVICE (self), "abs1", ix++, 0, 255, 0);
@@ -216,8 +215,6 @@ btic_test_device_class_init (BtIcTestDeviceClass * const klass)
 {
   GObjectClass *const gobject_class = G_OBJECT_CLASS (klass);
   BtIcDeviceClass *const bticdevice_class = BTIC_DEVICE_CLASS (klass);
-
-  g_type_class_add_private (klass, sizeof (BtIcTestDevicePrivate));
 
   gobject_class->set_property = btic_test_device_set_property;
   gobject_class->get_property = btic_test_device_get_property;

--- a/tests/lib/bml/e-class.c
+++ b/tests/lib/bml/e-class.c
@@ -48,8 +48,7 @@ case_teardown (void)
 
 //-- tests
 
-static void
-test_bmln_get_machine_info (BT_TEST_ARGS)
+START_TEST (test_bmln_get_machine_info)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -67,6 +66,7 @@ test_bmln_get_machine_info (BT_TEST_ARGS)
   bmln_close (bmh);
   BT_TEST_END;
 }
+END_TEST
 
 TCase *
 bml_class_example_case (void)

--- a/tests/lib/bml/e-core.c
+++ b/tests/lib/bml/e-core.c
@@ -46,19 +46,18 @@ case_teardown (void)
 
 //-- tests
 
-static void
-test_bml_setup (BT_TEST_ARGS)
+START_TEST (test_bml_setup)
 {
   BT_TEST_START;
   GST_INFO ("-- act --");
   int res = bml_setup ();
   GST_INFO ("-- assert --");
-  fail_unless (res, NULL);
+  fail_unless (res);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bml_finalize (BT_TEST_ARGS)
+START_TEST (test_bml_finalize)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -67,9 +66,9 @@ test_bml_finalize (BT_TEST_ARGS)
   bml_finalize ();
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bmln_master_info (BT_TEST_ARGS)
+START_TEST (test_bmln_master_info)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -78,9 +77,9 @@ test_bmln_master_info (BT_TEST_ARGS)
   bmln_set_master_info (120, 4, 44100);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bmln_open (BT_TEST_ARGS)
+START_TEST (test_bmln_open)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -94,6 +93,7 @@ test_bmln_open (BT_TEST_ARGS)
   bmln_close (bmh);
   BT_TEST_END;
 }
+END_TEST
 
 TCase *
 bml_core_example_case (void)

--- a/tests/lib/bml/t-core.c
+++ b/tests/lib/bml/t-core.c
@@ -46,8 +46,7 @@ case_teardown (void)
 
 //-- tests
 
-static void
-test_bmln_open_bad_path (BT_TEST_ARGS)
+START_TEST (test_bmln_open_bad_path)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -59,6 +58,7 @@ test_bmln_open_bad_path (BT_TEST_ARGS)
   fail_unless (bmh == NULL);
   BT_TEST_END;
 }
+END_TEST
 
 TCase *
 bml_core_test_case (void)

--- a/tests/lib/core/e-application.c
+++ b/tests/lib/core/e-application.c
@@ -45,8 +45,7 @@ case_teardown (void)
 
 //-- tests
 
-static void
-test_bt_application_new (BT_TEST_ARGS)
+START_TEST (test_bt_application_new)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -64,6 +63,7 @@ test_bt_application_new (BT_TEST_ARGS)
   ck_g_object_final_unref (app);
   BT_TEST_END;
 }
+END_TEST
 
 TCase *
 bt_application_example_case (void)

--- a/tests/lib/core/e-audio-session.c
+++ b/tests/lib/core/e-audio-session.c
@@ -45,8 +45,7 @@ case_teardown (void)
 
 //-- tests
 
-static void
-test_bt_audio_session_singleton (BT_TEST_ARGS)
+START_TEST (test_bt_audio_session_singleton)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -56,16 +55,16 @@ test_bt_audio_session_singleton (BT_TEST_ARGS)
   BtAudioSession *session2 = bt_audio_session_new ();
 
   GST_INFO ("-- assert --");
-  fail_unless (session1 == session2, NULL);
+  ck_assert (session1 == session2);
 
   GST_INFO ("-- cleanup --");
   g_object_unref (session2);
   ck_g_object_final_unref (session1);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_audio_session_no_session_element_for_fakesink (BT_TEST_ARGS)
+START_TEST (test_bt_audio_session_no_session_element_for_fakesink)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -75,12 +74,13 @@ test_bt_audio_session_no_session_element_for_fakesink (BT_TEST_ARGS)
   GstElement *e = bt_audio_session_get_sink_for ("fakesink", NULL);
 
   GST_INFO ("-- assert --");
-  fail_unless (e == NULL, NULL);
+  ck_assert (e == NULL);
 
   GST_INFO ("-- cleanup --");
   ck_g_object_final_unref (session);
   BT_TEST_END;
 }
+END_TEST
 
 
 TCase *

--- a/tests/lib/core/e-childproxy.c
+++ b/tests/lib/core/e-childproxy.c
@@ -54,8 +54,7 @@ case_teardown (void)
 
 //-- tests
 
-static void
-test_bt_child_proxy_get (BT_TEST_ARGS)
+START_TEST (test_bt_child_proxy_get)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -70,9 +69,9 @@ test_bt_child_proxy_get (BT_TEST_ARGS)
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_child_proxy_set (BT_TEST_ARGS)
+START_TEST (test_bt_child_proxy_set)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -88,9 +87,9 @@ test_bt_child_proxy_set (BT_TEST_ARGS)
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_child_proxy_get_property (BT_TEST_ARGS)
+START_TEST (test_bt_child_proxy_get_property)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -108,9 +107,9 @@ test_bt_child_proxy_get_property (BT_TEST_ARGS)
   g_value_unset (&value);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_child_proxy_set_property (BT_TEST_ARGS)
+START_TEST (test_bt_child_proxy_set_property)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -130,6 +129,7 @@ test_bt_child_proxy_set_property (BT_TEST_ARGS)
   g_value_unset (&value);
   BT_TEST_END;
 }
+END_TEST
 
 TCase *
 bt_child_proxy_example_case (void)

--- a/tests/lib/core/e-cmd-pattern-control-source.c
+++ b/tests/lib/core/e-cmd-pattern-control-source.c
@@ -41,9 +41,16 @@ test_setup (void)
   song = bt_song_new (app);
   bt_child_proxy_get ((gpointer) song, "sequence", &sequence, "song-info",
       &song_info, "song-info::tick-duration", &tick_time, NULL);
-  src1 = BT_MACHINE (bt_source_machine_new (song, "gen1",
+
+  BtMachineConstructorParams cparams;
+  cparams.id = "gen1";
+  cparams.song = song;
+  
+  src1 = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-mono-source", 0, NULL));
-  src2 = BT_MACHINE (bt_source_machine_new (song, "gen2",
+  
+  cparams.id = "gen2";
+  src2 = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-mono-source", 0, NULL));
 }
 
@@ -63,8 +70,7 @@ case_teardown (void)
 
 //-- tests
 
-static void
-test_bt_cmd_pattern_control_source_new (BT_TEST_ARGS)
+START_TEST (test_bt_cmd_pattern_control_source_new)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -76,16 +82,16 @@ test_bt_cmd_pattern_control_source_new (BT_TEST_ARGS)
       sequence, song_info, src1);
 
   GST_INFO ("-- assert --");
-  fail_unless (pcs != NULL, NULL);
+  ck_assert (pcs != NULL);
 
   GST_INFO ("-- cleanup --");
   gst_object_unref (pcs);
   gst_object_unref (m);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_cmd_pattern_control_source_normal_default_value (BT_TEST_ARGS)
+START_TEST (test_bt_cmd_pattern_control_source_normal_default_value)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -100,16 +106,16 @@ test_bt_cmd_pattern_control_source_normal_default_value (BT_TEST_ARGS)
   gst_object_sync_values (m, G_GUINT64_CONSTANT (0));
 
   GST_INFO ("-- assert --");
-  ck_assert_gobject_genum_eq (src1, "state", BT_MACHINE_STATE_NORMAL);
+  ck_assert_gobject_genum_eq (src1, "state", (gulong)BT_MACHINE_STATE_NORMAL);
 
   GST_INFO ("-- cleanup --");
   g_object_unref (pattern);
   gst_object_unref (m);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_cmd_pattern_control_source_set_mute (BT_TEST_ARGS)
+START_TEST (test_bt_cmd_pattern_control_source_set_mute)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -124,7 +130,7 @@ test_bt_cmd_pattern_control_source_set_mute (BT_TEST_ARGS)
   gst_object_sync_values (m, G_GUINT64_CONSTANT (0));
 
   GST_INFO ("-- assert --");
-  ck_assert_gobject_genum_eq (src1, "state", BT_MACHINE_STATE_MUTE);
+  ck_assert_gobject_genum_eq (src1, "state", (gulong)BT_MACHINE_STATE_MUTE);
   ck_assert_gobject_gboolean_eq (m, "mute", TRUE);
 
   GST_INFO ("-- cleanup --");
@@ -132,9 +138,9 @@ test_bt_cmd_pattern_control_source_set_mute (BT_TEST_ARGS)
   gst_object_unref (m);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_cmd_pattern_control_source_set_solo (BT_TEST_ARGS)
+START_TEST (test_bt_cmd_pattern_control_source_set_solo)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -151,7 +157,7 @@ test_bt_cmd_pattern_control_source_set_solo (BT_TEST_ARGS)
   gst_object_sync_values (m1, G_GUINT64_CONSTANT (0));
 
   GST_INFO ("-- assert --");
-  ck_assert_gobject_genum_eq (src1, "state", BT_MACHINE_STATE_SOLO);
+  ck_assert_gobject_genum_eq (src1, "state", (gulong)BT_MACHINE_STATE_SOLO);
   ck_assert_gobject_gboolean_eq (m1, "mute", FALSE);
   ck_assert_gobject_gboolean_eq (m2, "mute", TRUE);
 
@@ -161,6 +167,7 @@ test_bt_cmd_pattern_control_source_set_solo (BT_TEST_ARGS)
   gst_object_unref (m2);
   BT_TEST_END;
 }
+END_TEST
 
 TCase *
 bt_cmd_pattern_control_source_example_case (void)

--- a/tests/lib/core/e-cmd-pattern.c
+++ b/tests/lib/core/e-cmd-pattern.c
@@ -52,12 +52,16 @@ case_teardown (void)
 
 //-- tests
 
-static void
-test_bt_cmd_pattern_obj_mono1 (BT_TEST_ARGS)
+START_TEST (test_bt_cmd_pattern_obj_mono1)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
-  BtMachine *machine = BT_MACHINE (bt_source_machine_new (song, "gen",
+  
+  BtMachineConstructorParams cparams;
+  cparams.id = "gen";
+  cparams.song = song;
+  
+  BtMachine *machine = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-mono-source", 0L, NULL));
 
   GST_INFO ("-- act --");
@@ -71,13 +75,17 @@ test_bt_cmd_pattern_obj_mono1 (BT_TEST_ARGS)
   g_object_unref (pattern);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_cmd_pattern_obj_poly1 (BT_TEST_ARGS)
+START_TEST (test_bt_cmd_pattern_obj_poly1)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
-  BtMachine *machine = BT_MACHINE (bt_source_machine_new (song, "gen",
+  BtMachineConstructorParams cparams;
+  cparams.id = "gen";
+  cparams.song = song;
+  
+  BtMachine *machine = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-poly-source", 2L, NULL));
 
   GST_INFO ("-- act --");
@@ -91,6 +99,7 @@ test_bt_cmd_pattern_obj_poly1 (BT_TEST_ARGS)
   g_object_unref (pattern);
   BT_TEST_END;
 }
+END_TEST
 
 TCase *
 bt_cmd_pattern_example_case (void)

--- a/tests/lib/core/e-core.c
+++ b/tests/lib/core/e-core.c
@@ -52,28 +52,27 @@ case_teardown (void)
 //-- tests
 
 // test if the normal init call works with commandline arguments (no args)
-static void
-test_bt_core_init_no_args (BT_TEST_ARGS)
+START_TEST (test_bt_core_init_no_args)
 {
   BT_TEST_START;
   GST_INFO ("-- act --");
   bt_init (&test_argc, &test_argvptr);
   BT_TEST_END;
 }
+END_TEST
 
 // test if the init call handles correct null pointers
-static void
-test_bt_core_init_nullptr_args (BT_TEST_ARGS)
+START_TEST (test_bt_core_init_nullptr_args)
 {
   BT_TEST_START;
   GST_INFO ("-- act --");
   bt_init (NULL, NULL);
   BT_TEST_END;
 }
+END_TEST
 
 // test if the normal init call works with commandline arguments
-static void
-test_bt_core_init_args (BT_TEST_ARGS)
+START_TEST (test_bt_core_init_args)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -86,10 +85,11 @@ test_bt_core_init_args (BT_TEST_ARGS)
 
   GST_INFO ("-- assert --");
   ck_assert_int_eq (test_argc, 1);
-  fail_unless (check_file_contains_str (stdout, NULL,
-          "libbuzztrax-core-" BT_VERSION " from " PACKAGE_STRING), NULL);
+  ck_assert (check_file_contains_str (stdout, NULL,
+          "libbuzztrax-core-" BT_VERSION " from " PACKAGE_STRING));
   BT_TEST_END;
 }
+END_TEST
 
 TCase *
 bt_core_example_case (void)

--- a/tests/lib/core/e-machine.c
+++ b/tests/lib/core/e-machine.c
@@ -38,7 +38,11 @@ test_setup (void)
 {
   app = bt_test_application_new ();
   song = bt_song_new (app);
-  bt_sink_machine_new (song, "master", NULL);
+  BtMachineConstructorParams cparams;
+  cparams.id = "master";
+  cparams.song = song;
+  
+  bt_sink_machine_new (&cparams, NULL);
 
   registry = btic_registry_new ();
   device = (BtIcDevice *) btic_test_device_new ("test");
@@ -68,139 +72,168 @@ static gchar *element_names[] = {
 };
 static gulong element_voices[] = { 0, 0, 0, 1 };
 
-static void
-test_bt_machine_create (BT_TEST_ARGS)
+START_TEST (test_bt_machine_create)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
 
   GST_INFO ("-- act --");
   GError *err = NULL;
-  BtMachine *machine = BT_MACHINE (bt_source_machine_new (song, "gen",
+  BtMachineConstructorParams cparams;
+  cparams.id = "gen";
+  cparams.song = song;
+  
+  BtMachine *machine = BT_MACHINE (bt_source_machine_new (&cparams,
           element_names[_i], element_voices[_i], &err));
 
   GST_INFO ("-- assert --");
-  fail_unless (machine != NULL, NULL);
-  fail_unless (err == NULL, NULL);
-  fail_unless (!bt_machine_has_patterns (machine), NULL);
+  ck_assert (machine != NULL);
+  ck_assert (err == NULL);
+  ck_assert (!bt_machine_has_patterns (machine));
 
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
 /*
  * activate the input level meter in an unconnected machine
  */
-static void
-test_bt_machine_enable_input_level1 (BT_TEST_ARGS)
+START_TEST (test_bt_machine_enable_input_level1)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
+  BtMachineConstructorParams cparams;
+  cparams.id = "vol";
+  cparams.song = song;
+  
   BtMachine *machine =
-      BT_MACHINE (bt_processor_machine_new (song, "vol", "volume", 0, NULL));
+      BT_MACHINE (bt_processor_machine_new (&cparams, "volume", 0, NULL));
 
   GST_INFO ("-- act --");
   gboolean res = bt_machine_enable_input_pre_level (machine);
 
   GST_INFO ("-- assert --");
-  fail_unless (res == TRUE, NULL);
+  ck_assert (res == TRUE);
 
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
 /*
  * activate the input level meter in a connected machine
  */
-static void
-test_bt_machine_enable_input_level2 (BT_TEST_ARGS)
+START_TEST (test_bt_machine_enable_input_level2)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
+  BtMachineConstructorParams cparams;
+  cparams.id = "vol1";
+  cparams.song = song;
+  
   BtMachine *machine1 =
-      BT_MACHINE (bt_processor_machine_new (song, "vol1", "volume", 0, NULL));
+      BT_MACHINE (bt_processor_machine_new (&cparams, "volume", 0, NULL));
+
+  cparams.id = "vol2";
   BtMachine *machine2 =
-      BT_MACHINE (bt_processor_machine_new (song, "vol2", "volume", 0, NULL));
+      BT_MACHINE (bt_processor_machine_new (&cparams, "volume", 0, NULL));
   bt_wire_new (song, machine1, machine2, NULL);
 
   GST_INFO ("-- act --");
   gboolean res = bt_machine_enable_input_pre_level (machine2);
 
   GST_INFO ("-- assert --");
-  fail_unless (res == TRUE, NULL);
+  ck_assert (res == TRUE);
 
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
 /*
  * activate the input gain control in an unconnected machine
  */
-static void
-test_bt_machine_enable_input_gain1 (BT_TEST_ARGS)
+START_TEST (test_bt_machine_enable_input_gain1)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
+  BtMachineConstructorParams cparams;
+  cparams.id = "vol";
+  cparams.song = song;
+  
   BtMachine *machine =
-      BT_MACHINE (bt_processor_machine_new (song, "vol", "volume", 0, NULL));
+      BT_MACHINE (bt_processor_machine_new (&cparams, "volume", 0, NULL));
 
   GST_INFO ("-- act --");
   gboolean res = bt_machine_enable_input_gain (machine);
 
   GST_INFO ("-- assert --");
-  fail_unless (res == TRUE, NULL);
+  ck_assert (res == TRUE);
 
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
 /*
  * activate the output gain control in an unconnected machine
  */
-static void
-test_bt_machine_enable_output_gain1 (BT_TEST_ARGS)
+START_TEST (test_bt_machine_enable_output_gain1)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
+  BtMachineConstructorParams cparams;
+  cparams.id = "vol";
+  cparams.song = song;
+  
   BtMachine *machine =
-      BT_MACHINE (bt_processor_machine_new (song, "vol", "volume", 0, NULL));
+      BT_MACHINE (bt_processor_machine_new (&cparams, "volume", 0, NULL));
 
   GST_INFO ("-- act --");
   gboolean res = bt_machine_enable_output_gain (machine);
 
   GST_INFO ("-- assert --");
-  fail_unless (res == TRUE, NULL);
+  ck_assert (res == TRUE);
 
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
 /* add pattern */
-static void
-test_bt_machine_add_pattern (BT_TEST_ARGS)
+START_TEST (test_bt_machine_add_pattern)
 {
   BT_TEST_START;
+  BtMachineConstructorParams cparams;
+  cparams.id = "gen";
+  cparams.song = song;
+  
   GST_INFO ("-- arrange --");
-  BtMachine *machine = BT_MACHINE (bt_source_machine_new (song, "gen",
+  BtMachine *machine = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-poly-source", 1L, NULL));
 
   GST_INFO ("-- act --");
   BtPattern *pattern = bt_pattern_new (song, "pattern-name", 8L, machine);
 
   GST_INFO ("-- assert --");
-  fail_unless (bt_machine_has_patterns (machine), NULL);
+  ck_assert (bt_machine_has_patterns (machine));
 
   GST_INFO ("-- cleanup --");
   g_object_unref (pattern);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_machine_rem_pattern (BT_TEST_ARGS)
+START_TEST (test_bt_machine_rem_pattern)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
-  BtMachine *machine = BT_MACHINE (bt_source_machine_new (song, "gen",
+  BtMachineConstructorParams cparams;
+  cparams.id = "gen";
+  cparams.song = song;
+  
+  BtMachine *machine = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-poly-source", 1L, NULL));
   BtPattern *pattern = bt_pattern_new (song, "pattern-name", 8L, machine);
 
@@ -208,19 +241,23 @@ test_bt_machine_rem_pattern (BT_TEST_ARGS)
   bt_machine_remove_pattern (machine, (BtCmdPattern *) pattern);
 
   GST_INFO ("-- assert --");
-  fail_if (bt_machine_has_patterns (machine), NULL);
+  ck_assert (!bt_machine_has_patterns (machine));
 
   GST_INFO ("-- cleanup --");
   g_object_unref (pattern);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_machine_unique_pattern_name (BT_TEST_ARGS)
+START_TEST (test_bt_machine_unique_pattern_name)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
-  BtMachine *machine = BT_MACHINE (bt_source_machine_new (song, "gen",
+  BtMachineConstructorParams cparams;
+  cparams.id = "gen";
+  cparams.song = song;
+  
+  BtMachine *machine = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-poly-source", 1L, NULL));
   BtPattern *pattern = bt_pattern_new (song, "pattern-name", 8L, machine);
 
@@ -236,13 +273,17 @@ test_bt_machine_unique_pattern_name (BT_TEST_ARGS)
 
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_machine_next_pattern_name (BT_TEST_ARGS)
+START_TEST (test_bt_machine_next_pattern_name)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
-  BtMachine *machine = BT_MACHINE (bt_source_machine_new (song, "gen",
+  BtMachineConstructorParams cparams;
+  cparams.id = "gen";
+  cparams.song = song;
+  
+  BtMachine *machine = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-poly-source", 1L, NULL));
   BtPattern *pattern = bt_pattern_new (song, "00", 8L, machine);
 
@@ -258,15 +299,19 @@ test_bt_machine_next_pattern_name (BT_TEST_ARGS)
 
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_machine_check_voices (BT_TEST_ARGS)
+START_TEST (test_bt_machine_check_voices)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
 
   GST_INFO ("-- act --");
-  BtMachine *machine = BT_MACHINE (bt_source_machine_new (song, "gen",
+  BtMachineConstructorParams cparams;
+  cparams.id = "gen";
+  cparams.song = song;
+  
+  BtMachine *machine = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-poly-source", 2L, NULL));
 
   GST_INFO ("-- assert --");
@@ -279,16 +324,20 @@ test_bt_machine_check_voices (BT_TEST_ARGS)
   gst_object_unref (element);
   BT_TEST_END;
 }
+END_TEST
 
 /*
  * change voices and verify that voices in machine and patetrn are in sync
  */
-static void
-test_bt_machine_change_voices (BT_TEST_ARGS)
+START_TEST (test_bt_machine_change_voices)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
-  BtMachine *machine = BT_MACHINE (bt_source_machine_new (song, "gen",
+  BtMachineConstructorParams cparams;
+  cparams.id = "gen";
+  cparams.song = song;
+  
+  BtMachine *machine = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-poly-source", 1L, NULL));
   BtPattern *p1 = bt_pattern_new (song, "pattern-name1", 8L, machine);
   BtPattern *p2 = bt_pattern_new (song, "pattern-name2", 8L, machine);
@@ -297,26 +346,33 @@ test_bt_machine_change_voices (BT_TEST_ARGS)
   g_object_set (machine, "voices", 2, NULL);
 
   GST_INFO ("-- assert --");
-  ck_assert_gobject_gulong_eq (p1, "voices", 2);
-  ck_assert_gobject_gulong_eq (p2, "voices", 2);
+  ck_assert_gobject_gulong_eq (p1, "voices", 2L);
+  ck_assert_gobject_gulong_eq (p2, "voices", 2L);
 
   GST_INFO ("-- cleanup --");
   g_object_unref (p1);
   g_object_unref (p2);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_machine_state_mute_no_sideeffects (BT_TEST_ARGS)
+START_TEST (test_bt_machine_state_mute_no_sideeffects)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
+  BtMachineConstructorParams cparams;
+  cparams.id = "gen";
+  cparams.song = song;
+  
   BtMachine *src =
-      BT_MACHINE (bt_source_machine_new (song, "gen", "audiotestsrc", 0L,
+      BT_MACHINE (bt_source_machine_new (&cparams, "audiotestsrc", 0L,
           NULL));
+
+  cparams.id = "vol";
   BtMachine *proc =
-      BT_MACHINE (bt_processor_machine_new (song, "vol", "volume", 0L, NULL));
-  BtMachine *sink = BT_MACHINE (bt_sink_machine_new (song, "sink", NULL));
+      BT_MACHINE (bt_processor_machine_new (&cparams, "volume", 0L, NULL));
+  cparams.id = "sink";
+  BtMachine *sink = BT_MACHINE (bt_sink_machine_new (&cparams, NULL));
   bt_wire_new (song, src, proc, NULL);
   bt_wire_new (song, proc, sink, NULL);
 
@@ -331,19 +387,26 @@ test_bt_machine_state_mute_no_sideeffects (BT_TEST_ARGS)
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_machine_state_solo_resets_others (BT_TEST_ARGS)
+START_TEST (test_bt_machine_state_solo_resets_others)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
+  BtMachineConstructorParams cparams;
+  cparams.id = "gen1";
+  cparams.song = song;
+  
   BtMachine *src1 =
-      BT_MACHINE (bt_source_machine_new (song, "gen1", "audiotestsrc", 0L,
+      BT_MACHINE (bt_source_machine_new (&cparams, "audiotestsrc", 0L,
           NULL));
+
+  cparams.id = "gen2";
   BtMachine *src2 =
-      BT_MACHINE (bt_source_machine_new (song, "gen2", "audiotestsrc", 0L,
+      BT_MACHINE (bt_source_machine_new (&cparams, "audiotestsrc", 0L,
           NULL));
-  BtMachine *sink = BT_MACHINE (bt_sink_machine_new (song, "sink", NULL));
+  cparams.id = "sink";
+  BtMachine *sink = BT_MACHINE (bt_sink_machine_new (&cparams, NULL));
   bt_wire_new (song, src1, sink, NULL);
   bt_wire_new (song, src2, sink, NULL);
 
@@ -358,18 +421,25 @@ test_bt_machine_state_solo_resets_others (BT_TEST_ARGS)
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_machine_state_bypass_no_sideeffects (BT_TEST_ARGS)
+START_TEST (test_bt_machine_state_bypass_no_sideeffects)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
+  BtMachineConstructorParams cparams;
+  cparams.id = "gen";
+  cparams.song = song;
+  
   BtMachine *src =
-      BT_MACHINE (bt_source_machine_new (song, "gen", "audiotestsrc", 0L,
+      BT_MACHINE (bt_source_machine_new (&cparams, "audiotestsrc", 0L,
           NULL));
+
+  cparams.id = "vol";
   BtMachine *proc =
-      BT_MACHINE (bt_processor_machine_new (song, "vol", "volume", 0L, NULL));
-  BtMachine *sink = BT_MACHINE (bt_sink_machine_new (song, "sink", NULL));
+      BT_MACHINE (bt_processor_machine_new (&cparams, "volume", 0L, NULL));
+  cparams.id = "sink";
+  BtMachine *sink = BT_MACHINE (bt_sink_machine_new (&cparams, NULL));
   bt_wire_new (song, src, proc, NULL);
   bt_wire_new (song, proc, sink, NULL);
 
@@ -384,9 +454,9 @@ test_bt_machine_state_bypass_no_sideeffects (BT_TEST_ARGS)
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_machine_state_not_overridden (BT_TEST_ARGS)
+START_TEST (test_bt_machine_state_not_overridden)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -394,9 +464,17 @@ test_bt_machine_state_not_overridden (BT_TEST_ARGS)
       (BtSequence *) check_gobject_get_object_property (song, "sequence");
   BtSongInfo *song_info =
       BT_SONG_INFO (check_gobject_get_object_property (song, "song-info"));
-  BtMachine *src = BT_MACHINE (bt_source_machine_new (song, "gen",
+  
+  BtMachineConstructorParams cparams;
+  cparams.id = "gen";
+  cparams.song = song;
+  
+  BtMachine *src = BT_MACHINE (bt_source_machine_new (&cparams,
           "simsyn", 0L, NULL));
-  BtMachine *sink = BT_MACHINE (bt_sink_machine_new (song, "sink", NULL));
+  
+  cparams.id = "sink";
+  BtMachine *sink = BT_MACHINE (bt_sink_machine_new (&cparams, NULL));
+  
   bt_wire_new (song, src, sink, NULL);
   BtCmdPattern *pattern = bt_cmd_pattern_new (song, src, BT_PATTERN_CMD_SOLO);
   GstElement *element =
@@ -425,14 +503,18 @@ test_bt_machine_state_not_overridden (BT_TEST_ARGS)
   g_object_unref (song_info);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_machine_pretty_name (BT_TEST_ARGS)
+START_TEST (test_bt_machine_pretty_name)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
+  BtMachineConstructorParams cparams;
+  cparams.id = "audiotestsrc";
+  cparams.song = song;
+  
   BtMachine *src =
-      BT_MACHINE (bt_source_machine_new (song, "audiotestsrc", "audiotestsrc",
+      BT_MACHINE (bt_source_machine_new (&cparams, "audiotestsrc",
           0L, NULL));
 
   GST_INFO ("-- act --");
@@ -443,14 +525,18 @@ test_bt_machine_pretty_name (BT_TEST_ARGS)
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_machine_pretty_name_with_detail (BT_TEST_ARGS)
+START_TEST (test_bt_machine_pretty_name_with_detail)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
+  BtMachineConstructorParams cparams;
+  cparams.id = "gen";
+  cparams.song = song;
+  
   BtMachine *src =
-      BT_MACHINE (bt_source_machine_new (song, "gen", "audiotestsrc", 0L,
+      BT_MACHINE (bt_source_machine_new (&cparams, "audiotestsrc", 0L,
           NULL));
 
   GST_INFO ("-- act --");
@@ -461,13 +547,17 @@ test_bt_machine_pretty_name_with_detail (BT_TEST_ARGS)
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_machine_set_defaults (BT_TEST_ARGS)
+START_TEST (test_bt_machine_set_defaults)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
-  BtMachine *machine = BT_MACHINE (bt_source_machine_new (song, "id",
+  BtMachineConstructorParams cparams;
+  cparams.id = "id";
+  cparams.song = song;
+  
+  BtMachine *machine = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-mono-source", 0, NULL));
   GstObject *element =
       (GstObject *) check_gobject_get_object_property (machine, "machine");
@@ -486,13 +576,17 @@ test_bt_machine_set_defaults (BT_TEST_ARGS)
   gst_object_unref (element);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_machine_bind_parameter_control (BT_TEST_ARGS)
+START_TEST (test_bt_machine_bind_parameter_control)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
-  BtMachine *machine = BT_MACHINE (bt_source_machine_new (song, "id",
+  BtMachineConstructorParams cparams;
+  cparams.id = "id";
+  cparams.song = song;
+  
+  BtMachine *machine = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-mono-source", 0, NULL));
   GstObject *element =
       (GstObject *) check_gobject_get_object_property (machine, "machine");
@@ -513,13 +607,17 @@ test_bt_machine_bind_parameter_control (BT_TEST_ARGS)
   g_object_unref (control);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_machine_unbind_parameter_control (BT_TEST_ARGS)
+START_TEST (test_bt_machine_unbind_parameter_control)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
-  BtMachine *machine = BT_MACHINE (bt_source_machine_new (song, "id",
+  BtMachineConstructorParams cparams;
+  cparams.id = "id";
+  cparams.song = song;
+  
+  BtMachine *machine = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-mono-source", 0, NULL));
   GstObject *element =
       (GstObject *) check_gobject_get_object_property (machine, "machine");
@@ -541,13 +639,17 @@ test_bt_machine_unbind_parameter_control (BT_TEST_ARGS)
   g_object_unref (control);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_machine_unbind_parameter_controls (BT_TEST_ARGS)
+START_TEST (test_bt_machine_unbind_parameter_controls)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
-  BtMachine *machine = BT_MACHINE (bt_source_machine_new (song, "id",
+  BtMachineConstructorParams cparams;
+  cparams.id = "id";
+  cparams.song = song;
+  
+  BtMachine *machine = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-mono-source", 0, NULL));
   GstObject *element =
       (GstObject *) check_gobject_get_object_property (machine, "machine");
@@ -569,6 +671,7 @@ test_bt_machine_unbind_parameter_controls (BT_TEST_ARGS)
   g_object_unref (control);
   BT_TEST_END;
 }
+END_TEST
 
 
 TCase *

--- a/tests/lib/core/e-parameter-group.c
+++ b/tests/lib/core/e-parameter-group.c
@@ -56,8 +56,12 @@ case_teardown (void)
 BtParameterGroup *
 get_mono_parameter_group (void)
 {
+  BtMachineConstructorParams cparams;
+  cparams.id = "id";
+  cparams.song = song;
+  
   machine =
-      BT_MACHINE (bt_source_machine_new (song, "id",
+      BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-mono-source", 0, NULL));
   return bt_machine_get_global_param_group (machine);
 }
@@ -65,8 +69,7 @@ get_mono_parameter_group (void)
 
 //-- tests
 
-static void
-test_bt_parameter_group_param (BT_TEST_ARGS)
+START_TEST (test_bt_parameter_group_param)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -78,29 +81,30 @@ test_bt_parameter_group_param (BT_TEST_ARGS)
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_parameter_group_size (BT_TEST_ARGS)
+START_TEST (test_bt_parameter_group_size)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
   BtParameterGroup *pg = get_mono_parameter_group ();
 
   /* act && assert */
-  ck_assert_gobject_glong_eq (pg, "num-params", 6);
+  ck_assert_gobject_glong_eq (pg, "num-params", 6L);
 
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
 /* try describe on a machine that does not implement the interface */
-static void
-test_bt_parameter_group_describe (BT_TEST_ARGS)
+START_TEST (test_bt_parameter_group_describe)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
   BtParameterGroup *pg = get_mono_parameter_group ();
-  GValue val = { 0, };
+  GValue val = { 0, }
+END_TEST;
   g_value_init (&val, G_TYPE_ULONG);
   g_value_set_ulong (&val, 1L);
 
@@ -108,15 +112,15 @@ test_bt_parameter_group_describe (BT_TEST_ARGS)
   gchar *str = bt_parameter_group_describe_param_value (pg, 0, &val);
 
   GST_INFO ("-- assert --");
-  fail_unless (str == NULL, NULL);
+  ck_assert (str == NULL);
 
   GST_INFO ("-- cleanup --");
   g_value_unset (&val);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_parameter_group_get_trigger_param (BT_TEST_ARGS)
+START_TEST (test_bt_parameter_group_get_trigger_param)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -131,9 +135,9 @@ test_bt_parameter_group_get_trigger_param (BT_TEST_ARGS)
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_parameter_group_get_wave_param (BT_TEST_ARGS)
+START_TEST (test_bt_parameter_group_get_wave_param)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -148,16 +152,17 @@ test_bt_parameter_group_get_wave_param (BT_TEST_ARGS)
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_parameter_group_set_value (BT_TEST_ARGS)
+START_TEST (test_bt_parameter_group_set_value)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
   BtParameterGroup *pg = get_mono_parameter_group ();
   GstObject *element =
       (GstObject *) check_gobject_get_object_property (machine, "machine");
-  GValue val = { 0, };
+  GValue val = { 0, }
+END_TEST;
   g_value_init (&val, G_TYPE_ULONG);
   g_value_set_ulong (&val, 10L);
 
@@ -172,10 +177,10 @@ test_bt_parameter_group_set_value (BT_TEST_ARGS)
   g_value_unset (&val);
   BT_TEST_END;
 }
+END_TEST
 
 /* test setting a new default */
-static void
-test_bt_parameter_group_set_default (BT_TEST_ARGS)
+START_TEST (test_bt_parameter_group_set_default)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -197,9 +202,9 @@ test_bt_parameter_group_set_default (BT_TEST_ARGS)
   gst_object_unref (element);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_parameter_group_set_default_trigger (BT_TEST_ARGS)
+START_TEST (test_bt_parameter_group_set_default_trigger)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -221,9 +226,9 @@ test_bt_parameter_group_set_default_trigger (BT_TEST_ARGS)
   gst_object_unref (element);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_parameter_group_set_defaults (BT_TEST_ARGS)
+START_TEST (test_bt_parameter_group_set_defaults)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -245,9 +250,9 @@ test_bt_parameter_group_set_defaults (BT_TEST_ARGS)
   gst_object_unref (element);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_parameter_group_reset_all (BT_TEST_ARGS)
+START_TEST (test_bt_parameter_group_reset_all)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -267,6 +272,7 @@ test_bt_parameter_group_reset_all (BT_TEST_ARGS)
   gst_object_unref (element);
   BT_TEST_END;
 }
+END_TEST
 
 
 TCase *

--- a/tests/lib/core/e-parameter-group.c
+++ b/tests/lib/core/e-parameter-group.c
@@ -103,8 +103,8 @@ START_TEST (test_bt_parameter_group_describe)
   BT_TEST_START;
   GST_INFO ("-- arrange --");
   BtParameterGroup *pg = get_mono_parameter_group ();
-  GValue val = { 0, }
-END_TEST;
+  GValue val = { 0, };
+  
   g_value_init (&val, G_TYPE_ULONG);
   g_value_set_ulong (&val, 1L);
 
@@ -161,8 +161,8 @@ START_TEST (test_bt_parameter_group_set_value)
   BtParameterGroup *pg = get_mono_parameter_group ();
   GstObject *element =
       (GstObject *) check_gobject_get_object_property (machine, "machine");
-  GValue val = { 0, }
-END_TEST;
+  GValue val = { 0, };
+  
   g_value_init (&val, G_TYPE_ULONG);
   g_value_set_ulong (&val, 10L);
 

--- a/tests/lib/core/e-pattern-control-source.c
+++ b/tests/lib/core/e-pattern-control-source.c
@@ -42,7 +42,11 @@ test_setup (void)
   song = bt_song_new (app);
   bt_child_proxy_get ((gpointer) song, "sequence", &sequence, "song-info",
       &song_info, "song-info::tick-duration", &tick_time, NULL);
-  machine = BT_MACHINE (bt_source_machine_new (song, "gen",
+  BtMachineConstructorParams cparams;
+  cparams.id = "gen";
+  cparams.song = song;
+  
+  machine = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-mono-source", 0, NULL));
   element = GST_OBJECT (check_gobject_get_object_property (machine, "machine"));
   pg = bt_machine_get_global_param_group (machine);
@@ -65,8 +69,7 @@ case_teardown (void)
 
 //-- tests
 
-static void
-test_bt_pattern_control_source_new (BT_TEST_ARGS)
+START_TEST (test_bt_pattern_control_source_new)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -84,9 +87,9 @@ test_bt_pattern_control_source_new (BT_TEST_ARGS)
   gst_object_unref (pcs);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_pattern_control_source_normal_default_for_empty_pattern (BT_TEST_ARGS)
+START_TEST (test_bt_pattern_control_source_normal_default_for_empty_pattern)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -108,9 +111,9 @@ test_bt_pattern_control_source_normal_default_for_empty_pattern (BT_TEST_ARGS)
   g_object_unref (pattern);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_pattern_control_source_normal_default_for_cmd_pattern (BT_TEST_ARGS)
+START_TEST (test_bt_pattern_control_source_normal_default_for_cmd_pattern)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -133,9 +136,9 @@ test_bt_pattern_control_source_normal_default_for_cmd_pattern (BT_TEST_ARGS)
   g_object_unref (pattern);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_pattern_control_source_trigger_default_for_empty_pattern (BT_TEST_ARGS)
+START_TEST (test_bt_pattern_control_source_trigger_default_for_empty_pattern)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -154,9 +157,9 @@ test_bt_pattern_control_source_trigger_default_for_empty_pattern (BT_TEST_ARGS)
   g_object_unref (pattern);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_pattern_control_source_override_default_from_pattern (BT_TEST_ARGS)
+START_TEST (test_bt_pattern_control_source_override_default_from_pattern)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -180,9 +183,9 @@ test_bt_pattern_control_source_override_default_from_pattern (BT_TEST_ARGS)
   g_object_unref (pattern);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_pattern_control_source_restore_default_on_pattern_cleared (BT_TEST_ARGS)
+START_TEST (test_bt_pattern_control_source_restore_default_on_pattern_cleared)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -207,9 +210,9 @@ test_bt_pattern_control_source_restore_default_on_pattern_cleared (BT_TEST_ARGS)
   g_object_unref (pattern);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_pattern_control_source_change_pattern (BT_TEST_ARGS)
+START_TEST (test_bt_pattern_control_source_change_pattern)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -229,9 +232,9 @@ test_bt_pattern_control_source_change_pattern (BT_TEST_ARGS)
   g_object_unref (pattern);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_pattern_control_source_hold_normal (BT_TEST_ARGS)
+START_TEST (test_bt_pattern_control_source_hold_normal)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -253,9 +256,9 @@ test_bt_pattern_control_source_hold_normal (BT_TEST_ARGS)
   g_object_unref (pattern);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_pattern_control_source_release_trigger (BT_TEST_ARGS)
+START_TEST (test_bt_pattern_control_source_release_trigger)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -277,9 +280,9 @@ test_bt_pattern_control_source_release_trigger (BT_TEST_ARGS)
   g_object_unref (pattern);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_pattern_control_source_combine_pattern_shadows (BT_TEST_ARGS)
+START_TEST (test_bt_pattern_control_source_combine_pattern_shadows)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -305,9 +308,9 @@ test_bt_pattern_control_source_combine_pattern_shadows (BT_TEST_ARGS)
   g_object_unref (pattern2);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_pattern_control_source_combine_pattern_unshadows (BT_TEST_ARGS)
+START_TEST (test_bt_pattern_control_source_combine_pattern_unshadows)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -336,9 +339,9 @@ test_bt_pattern_control_source_combine_pattern_unshadows (BT_TEST_ARGS)
   g_object_unref (pattern2);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_pattern_control_source_combine_value_unshadows (BT_TEST_ARGS)
+START_TEST (test_bt_pattern_control_source_combine_value_unshadows)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -367,9 +370,9 @@ test_bt_pattern_control_source_combine_value_unshadows (BT_TEST_ARGS)
   g_object_unref (pattern2);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_pattern_control_source_combine_two_tracks (BT_TEST_ARGS)
+START_TEST (test_bt_pattern_control_source_combine_two_tracks)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -395,6 +398,7 @@ test_bt_pattern_control_source_combine_two_tracks (BT_TEST_ARGS)
   g_object_unref (pattern);
   BT_TEST_END;
 }
+END_TEST
 
 TCase *
 bt_pattern_control_source_example_case (void)

--- a/tests/lib/core/e-pattern-control-source.c
+++ b/tests/lib/core/e-pattern-control-source.c
@@ -81,7 +81,7 @@ START_TEST (test_bt_pattern_control_source_new)
       sequence, song_info, machine, pg);
 
   GST_INFO ("-- assert --");
-  fail_unless (pcs != NULL, NULL);
+  ck_assert (pcs != NULL);
 
   GST_INFO ("-- cleanup --");
   gst_object_unref (pcs);

--- a/tests/lib/core/e-pattern.c
+++ b/tests/lib/core/e-pattern.c
@@ -241,8 +241,8 @@ START_TEST (test_bt_pattern_copy)
   GST_INFO ("-- assert --");
   ck_assert (pattern2 != NULL);
   ck_assert (pattern2 != pattern1);
-  ck_assert_gobject_gulong_eq (pattern2, "voices", 2);
-  ck_assert_gobject_gulong_eq (pattern2, "length", 8);
+  ck_assert_gobject_gulong_eq (pattern2, "voices", 2L);
+  ck_assert_gobject_gulong_eq (pattern2, "length", 8L);
   ck_assert_str_eq_and_free (bt_pattern_get_global_event (pattern2, 0, 0), "5");
 
   GST_INFO ("-- cleanup --");
@@ -297,7 +297,7 @@ START_TEST (test_bt_pattern_enlarge_length)
   g_object_set (pattern, "length", 16L, NULL);
 
   GST_INFO ("-- assert --");
-  ck_assert_gobject_gulong_eq (pattern, "length", 16);
+  ck_assert_gobject_gulong_eq (pattern, "length", 16L);
   ck_assert_str_eq_and_free (bt_pattern_get_global_event (pattern, 0, 0), "5");
   ck_assert_str_eq_and_free (bt_pattern_get_global_event (pattern, 4, 0), "10");
   ck_assert_str_eq_and_free (bt_pattern_get_global_event (pattern, 10, 0),
@@ -327,7 +327,7 @@ START_TEST (test_bt_pattern_shrink_length)
   g_object_set (pattern, "length", 8L, NULL);
 
   GST_INFO ("-- assert --");
-  ck_assert_gobject_gulong_eq (pattern, "length", 8);
+  ck_assert_gobject_gulong_eq (pattern, "length", 8L);
   ck_assert_str_eq_and_free (bt_pattern_get_global_event (pattern, 0, 0), "5");
 
   GST_INFO ("-- cleanup --");
@@ -354,7 +354,7 @@ START_TEST (test_bt_pattern_enlarge_voices)
   g_object_set (machine, "voices", 2L, NULL);
 
   GST_INFO ("-- assert --");
-  ck_assert_gobject_gulong_eq (pattern, "voices", 2);
+  ck_assert_gobject_gulong_eq (pattern, "voices", 2L);
   ck_assert_str_eq_and_free (bt_pattern_get_global_event (pattern, 0, 0), "5");
   ck_assert_str_eq_and_free (bt_pattern_get_voice_event (pattern, 4, 0, 0),
       "10");
@@ -385,7 +385,7 @@ START_TEST (test_bt_pattern_shrink_voices)
   g_object_set (machine, "voices", 1L, NULL);
 
   GST_INFO ("-- assert --");
-  ck_assert_gobject_gulong_eq (pattern, "voices", 1);
+  ck_assert_gobject_gulong_eq (pattern, "voices", 1L);
   ck_assert_str_eq_and_free (bt_pattern_get_global_event (pattern, 0, 0), "5");
   ck_assert_str_eq_and_free (bt_pattern_get_voice_event (pattern, 4, 0, 0),
       "10");

--- a/tests/lib/core/e-pattern.c
+++ b/tests/lib/core/e-pattern.c
@@ -81,6 +81,7 @@ static gchar *element_names[] = {
   "buzztrax-test-poly-source", "buzztrax-test-poly-source"
 };
 static gulong element_voices[] = { 0, 0, 0, 1 };
+static gulong element_voices_expected[] = { 0, 0, 1, 1 };
 
 START_TEST (test_bt_pattern_obj_create)
 {
@@ -97,7 +98,7 @@ START_TEST (test_bt_pattern_obj_create)
   BtPattern *pattern = bt_pattern_new (song, "pattern-name", 8L, machine);
 
   GST_INFO ("-- assert --");
-  ck_assert_gobject_gulong_eq (pattern, "voices", element_voices[_i]);
+  ck_assert_gobject_gulong_eq (pattern, "voices", element_voices_expected[_i]);
 
   GST_INFO ("-- cleanup --");
   g_object_unref (pattern);

--- a/tests/lib/core/e-pattern.c
+++ b/tests/lib/core/e-pattern.c
@@ -52,12 +52,15 @@ case_teardown (void)
 
 //-- tests
 
-static void
-test_bt_pattern_name (BT_TEST_ARGS)
+START_TEST (test_bt_pattern_name)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
-  BtMachine *machine = BT_MACHINE (bt_source_machine_new (song, "gen",
+  BtMachineConstructorParams cparams;
+  cparams.id = "gen";
+  cparams.song = song;
+  
+  BtMachine *machine = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-mono-source", 0L, NULL));
 
   GST_INFO ("-- act --");
@@ -70,6 +73,7 @@ test_bt_pattern_name (BT_TEST_ARGS)
   g_object_unref (pattern);
   BT_TEST_END;
 }
+END_TEST
 
 
 static gchar *element_names[] = {
@@ -78,12 +82,15 @@ static gchar *element_names[] = {
 };
 static gulong element_voices[] = { 0, 0, 0, 1 };
 
-static void
-test_bt_pattern_obj_create (BT_TEST_ARGS)
+START_TEST (test_bt_pattern_obj_create)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
-  BtMachine *machine = BT_MACHINE (bt_source_machine_new (song, "gen",
+  BtMachineConstructorParams cparams;
+  cparams.id = "gen";
+  cparams.song = song;
+  
+  BtMachine *machine = BT_MACHINE (bt_source_machine_new (&cparams,
           element_names[_i], element_voices[_i], NULL));
 
   GST_INFO ("-- act --");
@@ -96,13 +103,17 @@ test_bt_pattern_obj_create (BT_TEST_ARGS)
   g_object_unref (pattern);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_pattern_obj_mono (BT_TEST_ARGS)
+START_TEST (test_bt_pattern_obj_mono)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
-  BtMachine *machine = BT_MACHINE (bt_source_machine_new (song, "gen",
+  BtMachineConstructorParams cparams;
+  cparams.id = "gen";
+  cparams.song = song;
+  
+  BtMachine *machine = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-mono-source", 0L, NULL));
   BtPattern *pattern = bt_pattern_new (song, "pattern-name", 8L, machine);
 
@@ -116,19 +127,23 @@ test_bt_pattern_obj_mono (BT_TEST_ARGS)
   ck_assert_str_eq_and_free (bt_pattern_get_global_event (pattern, 0, 1),
       "2.5");
   ck_assert_str_eq_and_free (bt_pattern_get_global_event (pattern, 0, 2), "1");
-  ck_assert_str_eq_and_free (bt_pattern_get_global_event (pattern, 6, 0), NULL);
+  ck_assert_ptr_null (bt_pattern_get_global_event (pattern, 6, 0));
 
   GST_INFO ("-- cleanup --");
   g_object_unref (pattern);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_pattern_obj_poly (BT_TEST_ARGS)
+START_TEST (test_bt_pattern_obj_poly)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
-  BtMachine *machine = BT_MACHINE (bt_source_machine_new (song, "gen",
+  BtMachineConstructorParams cparams;
+  cparams.id = "gen";
+  cparams.song = song;
+  
+  BtMachine *machine = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-poly-source", 2L, NULL));
   BtPattern *pattern = bt_pattern_new (song, "pattern-name", 8L, machine);
 
@@ -148,38 +163,48 @@ test_bt_pattern_obj_poly (BT_TEST_ARGS)
   g_object_unref (pattern);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_pattern_obj_wire1 (BT_TEST_ARGS)
+START_TEST (test_bt_pattern_obj_wire1)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
-  BtMachine *src_machine = BT_MACHINE (bt_source_machine_new (song, "gen",
+  BtMachineConstructorParams cparams;
+  cparams.id = "gen";
+  cparams.song = song;
+  
+  BtMachine *src_machine = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-mono-source", 0L, NULL));
-  BtMachine *sink_machine =
-      BT_MACHINE (bt_sink_machine_new (song, "sink", NULL));
+  cparams.id = "sink";
+  BtMachine *sink_machine = BT_MACHINE (bt_sink_machine_new (&cparams, NULL));
   BtWire *wire = bt_wire_new (song, src_machine, sink_machine, NULL);
 
   GST_INFO ("-- act --");
   BtPattern *pattern = bt_pattern_new (song, "pattern-name", 8L, sink_machine);
 
   GST_INFO ("-- assert --");
-  fail_unless (bt_pattern_get_wire_group (pattern, wire) != NULL, NULL);
+  ck_assert (bt_pattern_get_wire_group (pattern, wire) != NULL);
 
   GST_INFO ("-- cleanup --");
   g_object_unref (pattern);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_pattern_obj_wire2 (BT_TEST_ARGS)
+START_TEST (test_bt_pattern_obj_wire2)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
-  BtMachine *src_machine = BT_MACHINE (bt_source_machine_new (song, "gen",
+  BtMachineConstructorParams cparams;
+  cparams.id = "gen";
+  cparams.song = song;
+  
+  BtMachine *src_machine = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-mono-source", 0L, NULL));
+
+  cparams.id = "sink";
   BtMachine *sink_machine =
-      BT_MACHINE (bt_sink_machine_new (song, "sink", NULL));
+      BT_MACHINE (bt_sink_machine_new (&cparams, NULL));
   BtWire *wire = bt_wire_new (song, src_machine, sink_machine, NULL);
   BtPattern *pattern = bt_pattern_new (song, "pattern-name", 8L, sink_machine);
 
@@ -194,13 +219,17 @@ test_bt_pattern_obj_wire2 (BT_TEST_ARGS)
   g_object_unref (pattern);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_pattern_copy (BT_TEST_ARGS)
+START_TEST (test_bt_pattern_copy)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
-  BtMachine *machine = BT_MACHINE (bt_source_machine_new (song, "gen",
+  BtMachineConstructorParams cparams;
+  cparams.id = "gen";
+  cparams.song = song;
+  
+  BtMachine *machine = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-poly-source", 2L, NULL));
   BtPattern *pattern1 = bt_pattern_new (song, "pattern-name", 8L, machine);
   bt_pattern_set_global_event (pattern1, 0, 0, "5");
@@ -210,8 +239,8 @@ test_bt_pattern_copy (BT_TEST_ARGS)
   BtPattern *pattern2 = bt_pattern_copy (pattern1);
 
   GST_INFO ("-- assert --");
-  fail_unless (pattern2 != NULL, NULL);
-  fail_unless (pattern2 != pattern1, NULL);
+  ck_assert (pattern2 != NULL);
+  ck_assert (pattern2 != pattern1);
   ck_assert_gobject_gulong_eq (pattern2, "voices", 2);
   ck_assert_gobject_gulong_eq (pattern2, "length", 8);
   ck_assert_str_eq_and_free (bt_pattern_get_global_event (pattern2, 0, 0), "5");
@@ -221,13 +250,17 @@ test_bt_pattern_copy (BT_TEST_ARGS)
   g_object_unref (pattern2);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_pattern_has_data (BT_TEST_ARGS)
+START_TEST (test_bt_pattern_has_data)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
-  BtMachine *machine = BT_MACHINE (bt_source_machine_new (song, "gen",
+  BtMachineConstructorParams cparams;
+  cparams.id = "gen";
+  cparams.song = song;
+  
+  BtMachine *machine = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-poly-source", 1L, NULL));
   BtPattern *pattern = bt_pattern_new (song, "pattern-name", 8L, machine);
 
@@ -236,21 +269,25 @@ test_bt_pattern_has_data (BT_TEST_ARGS)
   bt_pattern_set_global_event (pattern, 4, 0, "10");
 
   GST_INFO ("-- assert --");
-  fail_unless (bt_pattern_test_tick (pattern, 0) == TRUE, NULL);
-  fail_unless (bt_pattern_test_tick (pattern, 4) == TRUE, NULL);
-  fail_unless (bt_pattern_test_tick (pattern, 1) == FALSE, NULL);
+  ck_assert (bt_pattern_test_tick (pattern, 0) == TRUE);
+  ck_assert (bt_pattern_test_tick (pattern, 4) == TRUE);
+  ck_assert (bt_pattern_test_tick (pattern, 1) == FALSE);
 
   GST_INFO ("-- cleanup --");
   g_object_unref (pattern);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_pattern_enlarge_length (BT_TEST_ARGS)
+START_TEST (test_bt_pattern_enlarge_length)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
-  BtMachine *machine = BT_MACHINE (bt_source_machine_new (song, "gen",
+  BtMachineConstructorParams cparams;
+  cparams.id = "gen";
+  cparams.song = song;
+  
+  BtMachine *machine = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-mono-source", 0L, NULL));
   BtPattern *pattern = bt_pattern_new (song, "pattern-name", 8L, machine);
   bt_pattern_set_global_event (pattern, 0, 0, "5");
@@ -270,13 +307,17 @@ test_bt_pattern_enlarge_length (BT_TEST_ARGS)
   g_object_unref (pattern);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_pattern_shrink_length (BT_TEST_ARGS)
+START_TEST (test_bt_pattern_shrink_length)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
-  BtMachine *machine = BT_MACHINE (bt_source_machine_new (song, "gen",
+  BtMachineConstructorParams cparams;
+  cparams.id = "gen";
+  cparams.song = song;
+  
+  BtMachine *machine = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-mono-source", 0L, NULL));
   BtPattern *pattern = bt_pattern_new (song, "pattern-name", 16L, machine);
   bt_pattern_set_global_event (pattern, 0, 0, "5");
@@ -293,13 +334,17 @@ test_bt_pattern_shrink_length (BT_TEST_ARGS)
   g_object_unref (pattern);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_pattern_enlarge_voices (BT_TEST_ARGS)
+START_TEST (test_bt_pattern_enlarge_voices)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
-  BtMachine *machine = BT_MACHINE (bt_source_machine_new (song, "gen",
+  BtMachineConstructorParams cparams;
+  cparams.id = "gen";
+  cparams.song = song;
+  
+  BtMachine *machine = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-poly-source", 1L, NULL));
   BtPattern *pattern = bt_pattern_new (song, "pattern-name", 8L, machine);
   bt_pattern_set_global_event (pattern, 0, 0, "5");
@@ -320,13 +365,17 @@ test_bt_pattern_enlarge_voices (BT_TEST_ARGS)
   g_object_unref (pattern);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_pattern_shrink_voices (BT_TEST_ARGS)
+START_TEST (test_bt_pattern_shrink_voices)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
-  BtMachine *machine = BT_MACHINE (bt_source_machine_new (song, "gen",
+  BtMachineConstructorParams cparams;
+  cparams.id = "gen";
+  cparams.song = song;
+  
+  BtMachine *machine = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-poly-source", 2L, NULL));
   BtPattern *pattern = bt_pattern_new (song, "pattern-name", 8L, machine);
   bt_pattern_set_global_event (pattern, 0, 0, "5");
@@ -345,13 +394,17 @@ test_bt_pattern_shrink_voices (BT_TEST_ARGS)
   g_object_unref (pattern);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_pattern_insert_row (BT_TEST_ARGS)
+START_TEST (test_bt_pattern_insert_row)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
-  BtMachine *machine = BT_MACHINE (bt_source_machine_new (song, "gen",
+  BtMachineConstructorParams cparams;
+  cparams.id = "gen";
+  cparams.song = song;
+  
+  BtMachine *machine = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-mono-source", 0L, NULL));
   BtPattern *pattern = bt_pattern_new (song, "pattern-name", 8L, machine);
   bt_pattern_set_global_event (pattern, 0, 0, "5");
@@ -370,13 +423,17 @@ test_bt_pattern_insert_row (BT_TEST_ARGS)
   g_object_unref (pattern);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_pattern_delete_row (BT_TEST_ARGS)
+START_TEST (test_bt_pattern_delete_row)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
-  BtMachine *machine = BT_MACHINE (bt_source_machine_new (song, "gen",
+  BtMachineConstructorParams cparams;
+  cparams.id = "gen";
+  cparams.song = song;
+  
+  BtMachine *machine = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-mono-source", 0L, NULL));
   BtPattern *pattern = bt_pattern_new (song, "pattern-name", 8L, machine);
   bt_pattern_set_global_event (pattern, 0, 0, "5");
@@ -394,23 +451,28 @@ test_bt_pattern_delete_row (BT_TEST_ARGS)
   g_object_unref (pattern);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_pattern_mono_get_global_vg (BT_TEST_ARGS)
+START_TEST (test_bt_pattern_mono_get_global_vg)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
-  BtMachine *machine = BT_MACHINE (bt_source_machine_new (song, "id",
+  BtMachineConstructorParams cparams;
+  cparams.id = "gen";
+  cparams.song = song;
+  
+  BtMachine *machine = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-mono-source", 0, NULL));
   BtPattern *pattern = bt_pattern_new (song, "pattern-name", 1L, machine);
 
   /* act && assert */
-  fail_unless (bt_pattern_get_global_group (pattern) != NULL, NULL);
+  ck_assert (bt_pattern_get_global_group (pattern) != NULL);
 
   GST_INFO ("-- cleanup --");
   g_object_unref (pattern);
   BT_TEST_END;
 }
+END_TEST
 
 TCase *
 bt_pattern_example_case (void)

--- a/tests/lib/core/e-processor-machine.c
+++ b/tests/lib/core/e-processor-machine.c
@@ -52,38 +52,45 @@ case_teardown (void)
 
 //-- tests
 
-static void
-test_bt_processor_machine_new (BT_TEST_ARGS)
+START_TEST (test_bt_processor_machine_new)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
 
   GST_INFO ("-- act --");
   GError *err = NULL;
+  BtMachineConstructorParams cparams;
+  cparams.id = "gen";
+  cparams.song = song;
+  
   BtProcessorMachine *machine =
-      bt_processor_machine_new (song, "vol", "volume", 0, &err);
+      bt_processor_machine_new (&cparams, "volume", 0, NULL);
 
   GST_INFO ("-- assert --");
-  fail_unless (machine != NULL, NULL);
-  fail_unless (err == NULL, NULL);
+  ck_assert (machine != NULL);
+  ck_assert (err == NULL);
 
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_processor_machine_def_patterns (BT_TEST_ARGS)
+START_TEST (test_bt_processor_machine_def_patterns)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
+  BtMachineConstructorParams cparams;
+  cparams.id = "vol";
+  cparams.song = song;
+  
   BtProcessorMachine *machine =
-      bt_processor_machine_new (song, "vol", "volume", 0, NULL);
+      bt_processor_machine_new (&cparams, "volume", 0, NULL);
 
   GST_INFO ("-- act --");
   GList *list = (GList *) check_gobject_get_ptr_property (machine, "patterns");
 
   GST_INFO ("-- assert --");
-  fail_unless (list != NULL, NULL);
+  ck_assert (list != NULL);
   ck_assert_int_eq (g_list_length (list), 3);   /* break+mute+bypass */
 
   GST_INFO ("-- cleanup --");
@@ -91,34 +98,42 @@ test_bt_processor_machine_def_patterns (BT_TEST_ARGS)
   g_list_free (list);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_processor_machine_pattern (BT_TEST_ARGS)
+START_TEST (test_bt_processor_machine_pattern)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
+  BtMachineConstructorParams cparams;
+  cparams.id = "vol";
+  cparams.song = song;
+  
   BtProcessorMachine *machine =
-      bt_processor_machine_new (song, "vol", "volume", 0, NULL);
+      bt_processor_machine_new (&cparams, "volume", 0, NULL);
 
   GST_INFO ("-- act --");
   BtPattern *pattern = bt_pattern_new (song, "pattern-name", 8L,
       BT_MACHINE (machine));
 
   GST_INFO ("-- assert --");
-  fail_unless (pattern != NULL, NULL);
+  ck_assert (pattern != NULL);
   ck_assert_gobject_gulong_eq (pattern, "voices", 0);
 
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_processor_machine_pattern_by_id (BT_TEST_ARGS)
+START_TEST (test_bt_processor_machine_pattern_by_id)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
+  BtMachineConstructorParams cparams;
+  cparams.id = "vol";
+  cparams.song = song;
+  
   BtProcessorMachine *machine =
-      bt_processor_machine_new (song, "vol", "volume", 0, NULL);
+      bt_processor_machine_new (&cparams, "volume", 0, NULL);
 
   GST_INFO ("-- act --");
   BtPattern *pattern = bt_pattern_new (song, "pattern-name", 8L,
@@ -132,34 +147,42 @@ test_bt_processor_machine_pattern_by_id (BT_TEST_ARGS)
   g_object_unref (pattern);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_processor_machine_pattern_by_index (BT_TEST_ARGS)
+START_TEST (test_bt_processor_machine_pattern_by_index)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
+  BtMachineConstructorParams cparams;
+  cparams.id = "vol";
+  cparams.song = song;
+  
   BtProcessorMachine *machine =
-      bt_processor_machine_new (song, "vol", "volume", 0, NULL);
+      bt_processor_machine_new (&cparams, "volume", 0, NULL);
 
   GST_INFO ("-- act --");
   BtCmdPattern *pattern = bt_machine_get_pattern_by_index (BT_MACHINE (machine),
       BT_PROCESSOR_MACHINE_PATTERN_INDEX_MUTE);
 
   GST_INFO ("-- assert --");
-  fail_unless (pattern != NULL, NULL);
+  ck_assert (pattern != NULL);
 
   GST_INFO ("-- cleanup --");
   g_object_unref (pattern);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_processor_machine_pattern_by_list (BT_TEST_ARGS)
+START_TEST (test_bt_processor_machine_pattern_by_list)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
+  BtMachineConstructorParams cparams;
+  cparams.id = "vol";
+  cparams.song = song;
+  
   BtProcessorMachine *machine =
-      bt_processor_machine_new (song, "vol", "volume", 0, NULL);
+      bt_processor_machine_new (&cparams, "volume", 0, NULL);
   BtPattern *pattern = bt_pattern_new (song, "pattern-name", 8L,
       BT_MACHINE (machine));
   GList *list = (GList *) check_gobject_get_ptr_property (machine, "patterns");
@@ -168,7 +191,7 @@ test_bt_processor_machine_pattern_by_list (BT_TEST_ARGS)
   GList *node = g_list_last (list);
 
   GST_INFO ("-- assert --");
-  fail_unless (node->data == pattern, NULL);
+  ck_assert (node->data == pattern);
 
   GST_INFO ("-- cleanup --");
   g_list_foreach (list, (GFunc) g_object_unref, NULL);
@@ -176,14 +199,18 @@ test_bt_processor_machine_pattern_by_list (BT_TEST_ARGS)
   g_object_unref (pattern);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_processor_machine_ref (BT_TEST_ARGS)
+START_TEST (test_bt_processor_machine_ref)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
+  BtMachineConstructorParams cparams;
+  cparams.id = "vol";
+  cparams.song = song;
+  
   BtProcessorMachine *machine =
-      bt_processor_machine_new (song, "vol", "volume", 0, NULL);
+      bt_processor_machine_new (&cparams, "volume", 0, NULL);
   BtSetup *setup = BT_SETUP (check_gobject_get_object_property (song, "setup"));
   gst_object_ref (machine);
 
@@ -198,6 +225,7 @@ test_bt_processor_machine_ref (BT_TEST_ARGS)
   g_object_unref (setup);
   BT_TEST_END;
 }
+END_TEST
 
 TCase *
 bt_processor_machine_example_case (void)

--- a/tests/lib/core/e-processor-machine.c
+++ b/tests/lib/core/e-processor-machine.c
@@ -117,7 +117,7 @@ START_TEST (test_bt_processor_machine_pattern)
 
   GST_INFO ("-- assert --");
   ck_assert (pattern != NULL);
-  ck_assert_gobject_gulong_eq (pattern, "voices", 0);
+  ck_assert_gobject_gulong_eq (pattern, "voices", 0L);
 
   GST_INFO ("-- cleanup --");
   BT_TEST_END;

--- a/tests/lib/core/e-sequence.c
+++ b/tests/lib/core/e-sequence.c
@@ -1047,7 +1047,10 @@ bt_sequence_example_case (void)
   tcase_add_test (tc, test_bt_sequence_shrink_track);
   tcase_add_test (tc, test_bt_sequence_enlarge_both_vals);
   //tcase_add_test(tc,test_bt_sequence_update);
-  tcase_add_test (tc, test_bt_sequence_ticks);
+
+  // See https://github.com/Buzztrax/buzztrax/issues/111
+  //tcase_add_test (tc, test_bt_sequence_ticks);
+  
   tcase_add_test (tc, test_bt_sequence_default_loop);
   tcase_add_test (tc, test_bt_sequence_enlarging_length_enlarges_loop);
   tcase_add_test (tc, test_bt_sequence_enlarging_length_keeps_loop);

--- a/tests/lib/core/e-sequence.c
+++ b/tests/lib/core/e-sequence.c
@@ -309,7 +309,7 @@ START_TEST (test_bt_sequence_enlarge_length)
   g_object_set (sequence, "length", 8L, NULL);
 
   GST_INFO ("-- assert --");
-  ck_assert_gobject_gulong_eq (sequence, "length", 8);
+  ck_assert_gobject_gulong_eq (sequence, "length", 8L);
 
   GST_INFO ("-- cleanup --");
   g_object_try_unref (sequence);
@@ -383,7 +383,7 @@ START_TEST (test_bt_sequence_shrink_length)
   g_object_set (sequence, "length", 8L, NULL);
 
   GST_INFO ("-- assert --");
-  ck_assert_gobject_gulong_eq (sequence, "length", 8);
+  ck_assert_gobject_gulong_eq (sequence, "length", 8L);
 
   GST_INFO ("-- cleanup --");
   g_object_try_unref (sequence);
@@ -409,7 +409,7 @@ START_TEST (test_bt_sequence_enlarge_track)
   bt_sequence_add_track (sequence, machine, -1);
 
   GST_INFO ("-- assert --");
-  ck_assert_gobject_gulong_eq (sequence, "tracks", 2);
+  ck_assert_gobject_gulong_eq (sequence, "tracks", 2L);
 
   GST_INFO ("-- cleanup --");
   g_object_try_unref (sequence);
@@ -435,7 +435,7 @@ START_TEST (test_bt_sequence_enlarge_track_vals)
   g_object_set (sequence, "tracks", 2L, NULL);
 
   GST_INFO ("-- assert --");
-  ck_assert_gobject_gulong_eq (sequence, "tracks", 2);
+  ck_assert_gobject_gulong_eq (sequence, "tracks", 2L);
   ck_assert_gobject_eq_and_unref (bt_sequence_get_machine (sequence, 0),
       machine);
   ck_assert_gobject_eq_and_unref (bt_sequence_get_machine (sequence, 1), NULL);
@@ -464,7 +464,7 @@ START_TEST (test_bt_sequence_shrink_track)
 
   GST_INFO ("-- act --");
   bt_sequence_remove_track_by_ix (sequence, 0);
-  ck_assert_gobject_gulong_eq (sequence, "tracks", 1);
+  ck_assert_gobject_gulong_eq (sequence, "tracks", 1L);
   ck_assert_gobject_eq_and_unref (bt_sequence_get_machine (sequence, 0),
       machine);
 
@@ -651,8 +651,8 @@ START_TEST (test_bt_sequence_default_loop)
   g_object_set (sequence, "loop", TRUE, NULL);
 
   GST_INFO ("-- assert --");
-  ck_assert_gobject_glong_eq (sequence, "loop-start", 0);
-  ck_assert_gobject_glong_eq (sequence, "loop-end", 16);
+  ck_assert_gobject_glong_eq (sequence, "loop-start", 0L);
+  ck_assert_gobject_glong_eq (sequence, "loop-end", 16L);
 
   GST_INFO ("-- cleanup --");
   g_object_unref (sequence);
@@ -673,8 +673,8 @@ START_TEST (test_bt_sequence_enlarging_length_enlarges_loop)
   g_object_set (sequence, "length", 24L, NULL);
 
   GST_INFO ("-- assert --");
-  ck_assert_gobject_glong_eq (sequence, "loop-start", 0);
-  ck_assert_gobject_glong_eq (sequence, "loop-end", 24);
+  ck_assert_gobject_glong_eq (sequence, "loop-start", 0L);
+  ck_assert_gobject_glong_eq (sequence, "loop-end", 24L);
 
   GST_INFO ("-- cleanup --");
   g_object_unref (sequence);
@@ -696,8 +696,8 @@ START_TEST (test_bt_sequence_enlarging_length_keeps_loop)
   g_object_set (sequence, "length", 12L, NULL);
 
   GST_INFO ("-- assert --");
-  ck_assert_gobject_glong_eq (sequence, "loop-start", 0);
-  ck_assert_gobject_glong_eq (sequence, "loop-end", 8);
+  ck_assert_gobject_glong_eq (sequence, "loop-start", 0L);
+  ck_assert_gobject_glong_eq (sequence, "loop-end", 8L);
 
   GST_INFO ("-- cleanup --");
   g_object_unref (sequence);
@@ -718,8 +718,8 @@ START_TEST (test_bt_sequence_shortening_length_truncates_loop)
   g_object_set (sequence, "length", 8L, NULL);
 
   GST_INFO ("-- assert --");
-  ck_assert_gobject_glong_eq (sequence, "loop-start", 0);
-  ck_assert_gobject_glong_eq (sequence, "loop-end", 8);
+  ck_assert_gobject_glong_eq (sequence, "loop-start", 0L);
+  ck_assert_gobject_glong_eq (sequence, "loop-end", 8L);
 
   GST_INFO ("-- cleanup --");
   g_object_unref (sequence);
@@ -969,7 +969,7 @@ START_TEST (test_bt_sequence_duration)
       gst_element_query_duration (sink_bin, GST_FORMAT_TIME, &duration);
 
   GST_INFO ("-- assert --");
-  fail_unless (res, NULL);
+  ck_assert (res);
   ck_assert_int64_ne (duration, G_GINT64_CONSTANT (-1));
   ck_assert_uint64_eq (duration, 16L * tick_time);
 
@@ -1011,7 +1011,7 @@ START_TEST (test_bt_sequence_duration_play)
       gst_element_query_duration (sink_bin, GST_FORMAT_TIME, &duration);
 
   GST_INFO ("-- assert --");
-  fail_unless (res, NULL);
+  ck_assert (res);
   ck_assert_int64_ne (duration, G_GINT64_CONSTANT (-1));
   ck_assert_uint64_eq (duration, 16L * tick_time);
 

--- a/tests/lib/core/e-sequence.c
+++ b/tests/lib/core/e-sequence.c
@@ -61,8 +61,7 @@ case_teardown (void)
 
 //-- tests
 
-static void
-test_bt_sequence_new (BT_TEST_ARGS)
+START_TEST (test_bt_sequence_new)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -72,19 +71,19 @@ test_bt_sequence_new (BT_TEST_ARGS)
       BT_SEQUENCE (check_gobject_get_object_property (song, "sequence"));
 
   GST_INFO ("-- assert --");
-  ck_assert_gobject_gulong_eq (sequence, "length", 0);
-  ck_assert_gobject_gulong_eq (sequence, "tracks", 0);
+  ck_assert_gobject_gulong_eq (sequence, "length", 0L);
+  ck_assert_gobject_gulong_eq (sequence, "tracks", 0L);
   ck_assert_gobject_gboolean_eq (sequence, "loop", FALSE);
-  ck_assert_gobject_glong_eq (sequence, "loop-start", -1);
-  ck_assert_gobject_glong_eq (sequence, "loop-end", -1);
+  ck_assert_gobject_glong_eq (sequence, "loop-start", -1L);
+  ck_assert_gobject_glong_eq (sequence, "loop-end", -1L);
 
   GST_INFO ("-- cleanup --");
   g_object_try_unref (sequence);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_sequence_labels (BT_TEST_ARGS)
+START_TEST (test_bt_sequence_labels)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -105,15 +104,19 @@ test_bt_sequence_labels (BT_TEST_ARGS)
   g_object_try_unref (sequence);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_sequence_append_track (BT_TEST_ARGS)
+START_TEST (test_bt_sequence_append_track)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
   BtSequence *sequence =
       BT_SEQUENCE (check_gobject_get_object_property (song, "sequence"));
-  BtMachine *gen = BT_MACHINE (bt_source_machine_new (song, "gen",
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "gen";
+  
+  BtMachine *gen = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-mono-source", 0, NULL));
 
   GST_INFO ("-- act --");
@@ -126,17 +129,21 @@ test_bt_sequence_append_track (BT_TEST_ARGS)
   g_object_try_unref (sequence);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_sequence_insert_track (BT_TEST_ARGS)
+START_TEST (test_bt_sequence_insert_track)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
   BtSequence *sequence =
       BT_SEQUENCE (check_gobject_get_object_property (song, "sequence"));
-  BtMachine *gen1 = BT_MACHINE (bt_source_machine_new (song, "gen",
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "gen";
+  
+  BtMachine *gen1 = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-mono-source", 0, NULL));
-  BtMachine *gen2 = BT_MACHINE (bt_source_machine_new (song, "gen",
+  BtMachine *gen2 = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-poly-source", 0, NULL));
   bt_sequence_add_track (sequence, gen1, -1);
 
@@ -150,18 +157,24 @@ test_bt_sequence_insert_track (BT_TEST_ARGS)
   g_object_try_unref (sequence);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_sequence_move_track_left (BT_TEST_ARGS)
+START_TEST (test_bt_sequence_move_track_left)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
   BtSequence *sequence =
       BT_SEQUENCE (check_gobject_get_object_property (song, "sequence"));
   g_object_set (sequence, "length", 16L, NULL);
-  BtMachine *gen1 = BT_MACHINE (bt_source_machine_new (song, "gen",
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "gen1";
+  
+  BtMachine *gen1 = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-mono-source", 0, NULL));
-  BtMachine *gen2 = BT_MACHINE (bt_source_machine_new (song, "gen",
+  
+  cparams.id = "gen2";
+  BtMachine *gen2 = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-poly-source", 0, NULL));
   bt_sequence_add_track (sequence, gen1, -1);
   bt_sequence_add_track (sequence, gen2, -1);
@@ -176,18 +189,22 @@ test_bt_sequence_move_track_left (BT_TEST_ARGS)
   g_object_try_unref (sequence);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_sequence_move_track_right (BT_TEST_ARGS)
+START_TEST (test_bt_sequence_move_track_right)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
   BtSequence *sequence =
       BT_SEQUENCE (check_gobject_get_object_property (song, "sequence"));
   g_object_set (sequence, "length", 16L, NULL);
-  BtMachine *gen1 = BT_MACHINE (bt_source_machine_new (song, "gen",
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "gen";
+  
+  BtMachine *gen1 = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-mono-source", 0, NULL));
-  BtMachine *gen2 = BT_MACHINE (bt_source_machine_new (song, "gen",
+  BtMachine *gen2 = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-poly-source", 0, NULL));
   bt_sequence_add_track (sequence, gen1, -1);
   bt_sequence_add_track (sequence, gen2, -1);
@@ -202,15 +219,19 @@ test_bt_sequence_move_track_right (BT_TEST_ARGS)
   g_object_try_unref (sequence);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_sequence_pattern (BT_TEST_ARGS)
+START_TEST (test_bt_sequence_pattern)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
   BtSequence *sequence =
       BT_SEQUENCE (check_gobject_get_object_property (song, "sequence"));
-  BtMachine *machine = BT_MACHINE (bt_source_machine_new (song, "gen",
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "gen";
+  
+  BtMachine *machine = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-mono-source", 0, NULL));
   BtCmdPattern *pattern =
       (BtCmdPattern *) bt_pattern_new (song, "pattern-name", 8L, machine);
@@ -234,15 +255,19 @@ test_bt_sequence_pattern (BT_TEST_ARGS)
   g_object_try_unref (sequence);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_sequence_get_tick_by_pattern (BT_TEST_ARGS)
+START_TEST (test_bt_sequence_get_tick_by_pattern)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
   BtSequence *sequence =
       BT_SEQUENCE (check_gobject_get_object_property (song, "sequence"));
-  BtMachine *machine = BT_MACHINE (bt_source_machine_new (song, "gen",
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "gen";
+  
+  BtMachine *machine = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-mono-source", 0, NULL));
   BtCmdPattern *p1 = (BtCmdPattern *) bt_pattern_new (song, "p1", 4L, machine);
   BtCmdPattern *p2 = (BtCmdPattern *) bt_pattern_new (song, "p2", 4L, machine);
@@ -264,15 +289,19 @@ test_bt_sequence_get_tick_by_pattern (BT_TEST_ARGS)
   g_object_try_unref (sequence);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_sequence_enlarge_length (BT_TEST_ARGS)
+START_TEST (test_bt_sequence_enlarge_length)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
   BtSequence *sequence =
       BT_SEQUENCE (check_gobject_get_object_property (song, "sequence"));
-  BtMachine *machine = BT_MACHINE (bt_source_machine_new (song, "gen",
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "gen";
+  
+  BtMachine *machine = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-mono-source", 0, NULL));
   bt_sequence_add_track (sequence, machine, -1);
 
@@ -286,9 +315,9 @@ test_bt_sequence_enlarge_length (BT_TEST_ARGS)
   g_object_try_unref (sequence);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_sequence_enlarge_length_check_labels (BT_TEST_ARGS)
+START_TEST (test_bt_sequence_enlarge_length_check_labels)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -308,9 +337,9 @@ test_bt_sequence_enlarge_length_check_labels (BT_TEST_ARGS)
   g_object_try_unref (sequence);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_sequence_enlarge_length_labels (BT_TEST_ARGS)
+START_TEST (test_bt_sequence_enlarge_length_labels)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -333,15 +362,19 @@ test_bt_sequence_enlarge_length_labels (BT_TEST_ARGS)
   g_object_try_unref (sequence);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_sequence_shrink_length (BT_TEST_ARGS)
+START_TEST (test_bt_sequence_shrink_length)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
   BtSequence *sequence =
       BT_SEQUENCE (check_gobject_get_object_property (song, "sequence"));
-  BtMachine *machine = BT_MACHINE (bt_source_machine_new (song, "gen",
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "gen";
+  
+  BtMachine *machine = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-mono-source", 0, NULL));
   bt_sequence_add_track (sequence, machine, -1);
   g_object_set (sequence, "length", 16L, NULL);
@@ -356,15 +389,19 @@ test_bt_sequence_shrink_length (BT_TEST_ARGS)
   g_object_try_unref (sequence);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_sequence_enlarge_track (BT_TEST_ARGS)
+START_TEST (test_bt_sequence_enlarge_track)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
   BtSequence *sequence =
       BT_SEQUENCE (check_gobject_get_object_property (song, "sequence"));
-  BtMachine *machine = BT_MACHINE (bt_source_machine_new (song, "gen-m",
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "gen-m";
+  
+  BtMachine *machine = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-mono-source", 0, NULL));
 
   GST_INFO ("-- act --");
@@ -378,15 +415,19 @@ test_bt_sequence_enlarge_track (BT_TEST_ARGS)
   g_object_try_unref (sequence);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_sequence_enlarge_track_vals (BT_TEST_ARGS)
+START_TEST (test_bt_sequence_enlarge_track_vals)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
   BtSequence *sequence =
       BT_SEQUENCE (check_gobject_get_object_property (song, "sequence"));
-  BtMachine *machine = BT_MACHINE (bt_source_machine_new (song, "gen",
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "gen";
+  
+  BtMachine *machine = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-mono-source", 0, NULL));
   bt_sequence_add_track (sequence, machine, -1);
 
@@ -403,15 +444,19 @@ test_bt_sequence_enlarge_track_vals (BT_TEST_ARGS)
   g_object_try_unref (sequence);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_sequence_shrink_track (BT_TEST_ARGS)
+START_TEST (test_bt_sequence_shrink_track)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
   BtSequence *sequence =
       BT_SEQUENCE (check_gobject_get_object_property (song, "sequence"));
-  BtMachine *machine = BT_MACHINE (bt_source_machine_new (song, "gen",
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "gen";
+  
+  BtMachine *machine = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-mono-source", 0, NULL));
   g_object_set (sequence, "length", 1L, NULL);
   bt_sequence_add_track (sequence, machine, -1);
@@ -427,15 +472,19 @@ test_bt_sequence_shrink_track (BT_TEST_ARGS)
   g_object_try_unref (sequence);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_sequence_enlarge_both_vals (BT_TEST_ARGS)
+START_TEST (test_bt_sequence_enlarge_both_vals)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
   BtSequence *sequence =
       BT_SEQUENCE (check_gobject_get_object_property (song, "sequence"));
-  BtMachine *machine = BT_MACHINE (bt_source_machine_new (song, "gen",
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "gen";
+  
+  BtMachine *machine = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-mono-source", 0, NULL));
   BtCmdPattern *pattern =
       (BtCmdPattern *) bt_pattern_new (song, "pattern-name", 8L, machine);
@@ -461,20 +510,24 @@ test_bt_sequence_enlarge_both_vals (BT_TEST_ARGS)
   g_object_try_unref (sequence);
   BT_TEST_END;
 }
+END_TEST
 
 /* we moved these updates to the app, to give the undo/redo framework a chance
  * to backup the data
  */
 #ifdef __CHECK_DISABLED__
 // test that removing patterns updates the sequence
-static void
-test_bt_sequence_update (BT_TEST_ARGS)
+START_TEST (test_bt_sequence_update)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
   BtSequence *sequence =
       BT_SEQUENCE (check_gobject_get_object_property (song, "sequence"));
-  BtMachine *machine = BT_MACHINE (bt_source_machine_new (song, "gen",
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "gen";
+  
+  BtMachine *machine = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-mono-source", 0, NULL));
   BtPattern *pattern = bt_pattern_new (song, "pattern-name", 8L, machine);
   g_object_set (sequence, "length", 4L, NULL);
@@ -493,6 +546,7 @@ test_bt_sequence_update (BT_TEST_ARGS)
   g_object_try_unref (sequence);
   BT_TEST_END;
 }
+END_TEST
 #endif
 
 #define TICK_CT 8L
@@ -521,8 +575,7 @@ on_bt_sequence_ticks_notify (GstObject * machine, GParamSpec * arg,
   }
 }
 
-static void
-test_bt_sequence_ticks (BT_TEST_ARGS)
+START_TEST (test_bt_sequence_ticks)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -533,9 +586,16 @@ test_bt_sequence_ticks (BT_TEST_ARGS)
       BT_SONG_INFO (check_gobject_get_object_property (song, "song-info"));
   g_object_set (song_info, "bpm", 250L, "tpb", 16L, NULL);
   /* need a real element that handles tempo and calls gst_object_sync */
-  BtMachine *src =
-      BT_MACHINE (bt_source_machine_new (song, "gen", "simsyn", 0, NULL));
-  BtMachine *sink = BT_MACHINE (bt_sink_machine_new (song, "sink", NULL));
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "gen";
+  
+  BtMachine *src = BT_MACHINE (bt_source_machine_new (&cparams,
+      "simsyn", 0, NULL));
+
+
+  cparams.id = "sink";
+  BtMachine *sink = BT_MACHINE (bt_sink_machine_new (&cparams, NULL));
   bt_wire_new (song, src, sink, NULL);
   BtPattern *pattern = bt_pattern_new (song, "pattern-name", TICK_CT, src);
   GstObject *element =
@@ -575,11 +635,11 @@ test_bt_sequence_ticks (BT_TEST_ARGS)
   g_object_unref (song_info);
   BT_TEST_END;
 }
+END_TEST
 
 #undef TICK_CT
 
-static void
-test_bt_sequence_default_loop (BT_TEST_ARGS)
+START_TEST (test_bt_sequence_default_loop)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -598,9 +658,9 @@ test_bt_sequence_default_loop (BT_TEST_ARGS)
   g_object_unref (sequence);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_sequence_enlarging_length_enlarges_loop (BT_TEST_ARGS)
+START_TEST (test_bt_sequence_enlarging_length_enlarges_loop)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -620,9 +680,9 @@ test_bt_sequence_enlarging_length_enlarges_loop (BT_TEST_ARGS)
   g_object_unref (sequence);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_sequence_enlarging_length_keeps_loop (BT_TEST_ARGS)
+START_TEST (test_bt_sequence_enlarging_length_keeps_loop)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -643,9 +703,9 @@ test_bt_sequence_enlarging_length_keeps_loop (BT_TEST_ARGS)
   g_object_unref (sequence);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_sequence_shortening_length_truncates_loop (BT_TEST_ARGS)
+START_TEST (test_bt_sequence_shortening_length_truncates_loop)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -665,9 +725,9 @@ test_bt_sequence_shortening_length_truncates_loop (BT_TEST_ARGS)
   g_object_unref (sequence);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_sequence_shortening_length_disables_loop (BT_TEST_ARGS)
+START_TEST (test_bt_sequence_shortening_length_disables_loop)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -687,19 +747,23 @@ test_bt_sequence_shortening_length_disables_loop (BT_TEST_ARGS)
   g_object_unref (sequence);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_sequence_insert_rows (BT_TEST_ARGS)
+START_TEST (test_bt_sequence_insert_rows)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
   BtSequence *sequence =
       BT_SEQUENCE (check_gobject_get_object_property (song, "sequence"));
   g_object_set (sequence, "length", 16L, NULL);
-  BtMachine *gen =
-      BT_MACHINE (bt_source_machine_new (song, "gen", "audiotestsrc", 0L,
-          NULL));
-  BtMachine *sink = BT_MACHINE (bt_sink_machine_new (song, "master", NULL));
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "gen";
+  
+  BtMachine *gen = BT_MACHINE (bt_source_machine_new (&cparams,
+      "audiotestsrc", 0L, NULL));
+  cparams.id = "master";
+  BtMachine *sink = BT_MACHINE (bt_sink_machine_new (&cparams, NULL));
   bt_wire_new (song, gen, sink, NULL);
   BtCmdPattern *pattern =
       (BtCmdPattern *) bt_pattern_new (song, "melo", 8L, gen);
@@ -719,19 +783,23 @@ test_bt_sequence_insert_rows (BT_TEST_ARGS)
   g_object_unref (sequence);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_sequence_insert_rows_shifts_out (BT_TEST_ARGS)
+START_TEST (test_bt_sequence_insert_rows_shifts_out)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
   BtSequence *sequence =
       BT_SEQUENCE (check_gobject_get_object_property (song, "sequence"));
   g_object_set (sequence, "length", 8L, NULL);
-  BtMachine *gen =
-      BT_MACHINE (bt_source_machine_new (song, "gen", "audiotestsrc", 0L,
-          NULL));
-  BtMachine *sink = BT_MACHINE (bt_sink_machine_new (song, "master", NULL));
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "gen";
+  
+  BtMachine *gen = BT_MACHINE (bt_source_machine_new (&cparams,
+      "audiotestsrc", 0L, NULL));
+  cparams.id = "master";
+  BtMachine *sink = BT_MACHINE (bt_sink_machine_new (&cparams, NULL));
   bt_wire_new (song, gen, sink, NULL);
   BtCmdPattern *pattern =
       (BtCmdPattern *) bt_pattern_new (song, "melo", 8L, gen);
@@ -750,19 +818,24 @@ test_bt_sequence_insert_rows_shifts_out (BT_TEST_ARGS)
   g_object_unref (sequence);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_sequence_insert_full_rows (BT_TEST_ARGS)
+START_TEST (test_bt_sequence_insert_full_rows)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
   BtSequence *sequence =
       BT_SEQUENCE (check_gobject_get_object_property (song, "sequence"));
   g_object_set (sequence, "length", 16L, NULL);
-  BtMachine *gen =
-      BT_MACHINE (bt_source_machine_new (song, "gen", "audiotestsrc", 0L,
-          NULL));
-  BtMachine *sink = BT_MACHINE (bt_sink_machine_new (song, "master", NULL));
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "gen";
+  
+  BtMachine *gen = BT_MACHINE (bt_source_machine_new (&cparams,
+      "audiotestsrc", 0L, NULL));
+  
+  cparams.id = "master";
+  BtMachine *sink = BT_MACHINE (bt_sink_machine_new (&cparams, NULL));
   bt_wire_new (song, gen, sink, NULL);
   BtCmdPattern *pattern =
       (BtCmdPattern *) bt_pattern_new (song, "melo", 8L, gen);
@@ -787,19 +860,24 @@ test_bt_sequence_insert_full_rows (BT_TEST_ARGS)
   g_object_unref (sequence);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_sequence_delete_rows (BT_TEST_ARGS)
+START_TEST (test_bt_sequence_delete_rows)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
   BtSequence *sequence =
       BT_SEQUENCE (check_gobject_get_object_property (song, "sequence"));
   g_object_set (sequence, "length", 16L, NULL);
-  BtMachine *gen =
-      BT_MACHINE (bt_source_machine_new (song, "gen", "audiotestsrc", 0L,
-          NULL));
-  BtMachine *sink = BT_MACHINE (bt_sink_machine_new (song, "master", NULL));
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "gen";
+  
+  BtMachine *gen = BT_MACHINE (bt_source_machine_new (&cparams,
+      "audiotestsrc", 0L, NULL));
+
+  cparams.id = "master";
+  BtMachine *sink = BT_MACHINE (bt_sink_machine_new (&cparams, NULL));
   bt_wire_new (song, gen, sink, NULL);
   BtCmdPattern *pattern =
       (BtCmdPattern *) bt_pattern_new (song, "melo", 8L, gen);
@@ -819,19 +897,24 @@ test_bt_sequence_delete_rows (BT_TEST_ARGS)
   g_object_unref (sequence);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_sequence_delete_full_rows (BT_TEST_ARGS)
+START_TEST (test_bt_sequence_delete_full_rows)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
   BtSequence *sequence =
       BT_SEQUENCE (check_gobject_get_object_property (song, "sequence"));
   g_object_set (sequence, "length", 16L, NULL);
-  BtMachine *gen =
-      BT_MACHINE (bt_source_machine_new (song, "gen", "audiotestsrc", 0L,
-          NULL));
-  BtMachine *sink = BT_MACHINE (bt_sink_machine_new (song, "master", NULL));
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "gen";
+  
+  BtMachine *gen = BT_MACHINE (bt_source_machine_new (&cparams,
+      "audiotestsrc", 0L, NULL));
+
+  cparams.id = "sink";
+  BtMachine *sink = BT_MACHINE (bt_sink_machine_new (&cparams, NULL));
   bt_wire_new (song, gen, sink, NULL);
   BtCmdPattern *pattern =
       (BtCmdPattern *) bt_pattern_new (song, "melo", 8L, gen);
@@ -856,20 +939,25 @@ test_bt_sequence_delete_full_rows (BT_TEST_ARGS)
   g_object_unref (sequence);
   BT_TEST_END;
 }
+END_TEST
 
 
-static void
-test_bt_sequence_duration (BT_TEST_ARGS)
+START_TEST (test_bt_sequence_duration)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
   BtSequence *sequence =
       BT_SEQUENCE (check_gobject_get_object_property (song, "sequence"));
   g_object_set (sequence, "length", 16L, NULL);
-  BtMachine *gen =
-      BT_MACHINE (bt_source_machine_new (song, "gen", "audiotestsrc", 0L,
-          NULL));
-  BtMachine *sink = BT_MACHINE (bt_sink_machine_new (song, "master", NULL));
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "gen";
+  
+  BtMachine *gen = BT_MACHINE (bt_source_machine_new (&cparams,
+      "audiotestsrc", 0L, NULL));
+
+  cparams.id = "master";
+  BtMachine *sink = BT_MACHINE (bt_sink_machine_new (&cparams, NULL));
   bt_wire_new (song, gen, sink, NULL);
   GstElement *sink_bin =
       GST_ELEMENT (check_gobject_get_object_property (sink, "machine"));
@@ -890,19 +978,24 @@ test_bt_sequence_duration (BT_TEST_ARGS)
   g_object_unref (sequence);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_sequence_duration_play (BT_TEST_ARGS)
+START_TEST (test_bt_sequence_duration_play)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
   BtSequence *sequence =
       BT_SEQUENCE (check_gobject_get_object_property (song, "sequence"));
   g_object_set (sequence, "length", 16L, NULL);
-  BtMachine *gen =
-      BT_MACHINE (bt_source_machine_new (song, "gen", "audiotestsrc", 0L,
-          NULL));
-  BtMachine *sink = BT_MACHINE (bt_sink_machine_new (song, "master", NULL));
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "gen";
+  
+  BtMachine *gen = BT_MACHINE (bt_source_machine_new (&cparams,
+      "audiotestsrc", 0L, NULL));
+
+  cparams.id = "master";
+  BtMachine *sink = BT_MACHINE (bt_sink_machine_new (&cparams, NULL));
   bt_wire_new (song, gen, sink, NULL);
   GstElement *element =
       (GstElement *) check_gobject_get_object_property (gen, "machine");
@@ -929,6 +1022,7 @@ test_bt_sequence_duration_play (BT_TEST_ARGS)
   g_object_unref (sequence);
   BT_TEST_END;
 }
+END_TEST
 
 
 TCase *

--- a/tests/lib/core/e-settings.c
+++ b/tests/lib/core/e-settings.c
@@ -45,8 +45,7 @@ case_teardown (void)
 
 //-- tests
 
-static void
-test_bt_settings_singleton (BT_TEST_ARGS)
+START_TEST (test_bt_settings_singleton)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -56,16 +55,16 @@ test_bt_settings_singleton (BT_TEST_ARGS)
   BtSettings *settings2 = bt_settings_make ();
 
   GST_INFO ("-- assert --");
-  fail_unless (settings1 == settings2, NULL);
+  ck_assert (settings1 == settings2);
 
   GST_INFO ("-- cleanup --");
   g_object_unref (settings2);
   ck_g_object_final_unref (settings1);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_settings_get_audiosink1 (BT_TEST_ARGS)
+START_TEST (test_bt_settings_get_audiosink1)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -85,9 +84,9 @@ test_bt_settings_get_audiosink1 (BT_TEST_ARGS)
   g_object_unref (settings);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_settings_ic_playback_spec (BT_TEST_ARGS)
+START_TEST (test_bt_settings_ic_playback_spec)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -105,6 +104,7 @@ test_bt_settings_ic_playback_spec (BT_TEST_ARGS)
   g_free (s2);
   BT_TEST_END;
 }
+END_TEST
 
 
 TCase *

--- a/tests/lib/core/e-setup.c
+++ b/tests/lib/core/e-setup.c
@@ -52,8 +52,7 @@ case_teardown (void)
 
 //-- tests
 
-static void
-test_bt_setup_new (BT_TEST_ARGS)
+START_TEST (test_bt_setup_new)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -64,23 +63,27 @@ test_bt_setup_new (BT_TEST_ARGS)
   g_object_get (G_OBJECT (setup), "machines", &machines, "wires", &wires, NULL);
 
   GST_INFO ("-- assert --");
-  fail_unless (machines == NULL, NULL);
-  fail_unless (wires == NULL, NULL);
+  ck_assert (machines == NULL);
+  ck_assert (wires == NULL);
 
   GST_INFO ("-- cleanup --");
   g_object_unref (setup);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_setup_machine_add_id (BT_TEST_ARGS)
+START_TEST (test_bt_setup_machine_add_id)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
   BtSetup *setup = BT_SETUP (check_gobject_get_object_property (song, "setup"));
 
   GST_INFO ("-- act --");
-  BtMachine *source = BT_MACHINE (bt_source_machine_new (song, "src",
+  BtMachineConstructorParams cparams;
+  cparams.id = "src";
+  cparams.song = song;
+  
+  BtMachine *source = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-mono-source", 0, NULL));
 
   GST_INFO ("-- assert --");
@@ -91,14 +94,18 @@ test_bt_setup_machine_add_id (BT_TEST_ARGS)
   g_object_unref (setup);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_setup_machine_rem_id (BT_TEST_ARGS)
+START_TEST (test_bt_setup_machine_rem_id)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
   BtSetup *setup = BT_SETUP (check_gobject_get_object_property (song, "setup"));
-  BtMachine *source = BT_MACHINE (bt_source_machine_new (song, "src",
+  BtMachineConstructorParams cparams;
+  cparams.id = "src";
+  cparams.song = song;
+  
+  BtMachine *source = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-mono-source", 0, NULL));
 
   GST_INFO ("-- act --");
@@ -112,39 +119,49 @@ test_bt_setup_machine_rem_id (BT_TEST_ARGS)
   g_object_unref (setup);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_setup_machine_add_updates_list (BT_TEST_ARGS)
+START_TEST (test_bt_setup_machine_add_updates_list)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
   BtSetup *setup = BT_SETUP (check_gobject_get_object_property (song, "setup"));
-  BtMachine *source = BT_MACHINE (bt_source_machine_new (song, "src",
+  BtMachineConstructorParams cparams;
+  cparams.id = "src";
+  cparams.song = song;
+  
+  BtMachine *source = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-mono-source", 0, NULL));
 
   GST_INFO ("-- act --");
   GList *list = (GList *) check_gobject_get_ptr_property (setup, "machines");
 
   GST_INFO ("-- assert --");
-  fail_unless (list != NULL, NULL);
+  ck_assert (list != NULL);
   ck_assert_int_eq (g_list_length (list), 1);
-  fail_unless ((BtMachine *) list->data == source, NULL);
+  ck_assert ((BtMachine *) list->data == source);
 
   GST_INFO ("-- cleanup --");
   g_list_free (list);
   g_object_unref (setup);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_setup_wire_add_machine_id (BT_TEST_ARGS)
+START_TEST (test_bt_setup_wire_add_machine_id)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
   BtSetup *setup = BT_SETUP (check_gobject_get_object_property (song, "setup"));
-  BtMachine *source = BT_MACHINE (bt_source_machine_new (song, "src",
+  BtMachineConstructorParams cparams;
+  cparams.id = "src";
+  cparams.song = song;
+  
+  BtMachine *source = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-mono-source", 0, NULL));
-  BtMachine *sink = BT_MACHINE (bt_sink_machine_new (song, "sink", NULL));
+  
+  cparams.id = "sink";
+  BtMachine *sink = BT_MACHINE (bt_sink_machine_new (&cparams, NULL));
 
   GST_INFO ("-- act --");
   BtWire *wire = bt_wire_new (song, source, sink, NULL);
@@ -157,16 +174,23 @@ test_bt_setup_wire_add_machine_id (BT_TEST_ARGS)
   g_object_unref (setup);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_setup_wire_rem_machine_id (BT_TEST_ARGS)
+START_TEST (test_bt_setup_wire_rem_machine_id)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
   BtSetup *setup = BT_SETUP (check_gobject_get_object_property (song, "setup"));
-  BtMachine *source = BT_MACHINE (bt_source_machine_new (song, "src",
+  BtMachineConstructorParams cparams;
+  cparams.id = "src";
+  cparams.song = song;
+  
+  BtMachine *source = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-mono-source", 0, NULL));
-  BtMachine *sink = BT_MACHINE (bt_sink_machine_new (song, "sink", NULL));
+  
+  cparams.id = "sink";
+  BtMachine *sink = BT_MACHINE (bt_sink_machine_new (&cparams, NULL));
+  
   BtWire *wire = bt_wire_new (song, source, sink, NULL);
 
   GST_INFO ("-- act --");
@@ -180,23 +204,30 @@ test_bt_setup_wire_rem_machine_id (BT_TEST_ARGS)
   g_object_unref (setup);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_setup_wire_add_src_list (BT_TEST_ARGS)
+START_TEST (test_bt_setup_wire_add_src_list)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
   BtSetup *setup = BT_SETUP (check_gobject_get_object_property (song, "setup"));
-  BtMachine *source = BT_MACHINE (bt_source_machine_new (song, "src",
+  BtMachineConstructorParams cparams;
+  cparams.id = "src";
+  cparams.song = song;
+  
+  BtMachine *source = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-mono-source", 0, NULL));
-  BtMachine *sink = BT_MACHINE (bt_sink_machine_new (song, "sink", NULL));
+  
+  cparams.id = "sink";
+  BtMachine *sink = BT_MACHINE (bt_sink_machine_new (&cparams, NULL));
+  
   BtWire *wire = bt_wire_new (song, source, sink, NULL);
 
   GST_INFO ("-- act --");
   GList *list = bt_setup_get_wires_by_src_machine (setup, source);
 
   GST_INFO ("-- assert --");
-  fail_unless (list != NULL, NULL);
+  ck_assert (list != NULL);
   ck_assert_int_eq (g_list_length (list), 1);
   ck_assert_gobject_eq_and_unref (BT_WIRE (g_list_first (list)->data), wire);
 
@@ -205,23 +236,30 @@ test_bt_setup_wire_add_src_list (BT_TEST_ARGS)
   g_object_unref (setup);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_setup_wire_add_dst_list (BT_TEST_ARGS)
+START_TEST (test_bt_setup_wire_add_dst_list)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
   BtSetup *setup = BT_SETUP (check_gobject_get_object_property (song, "setup"));
-  BtMachine *source = BT_MACHINE (bt_source_machine_new (song, "src",
+  BtMachineConstructorParams cparams;
+  cparams.id = "src";
+  cparams.song = song;
+  
+  BtMachine *source = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-mono-source", 0, NULL));
-  BtMachine *sink = BT_MACHINE (bt_sink_machine_new (song, "sink", NULL));
+  
+  cparams.id = "sink";
+  BtMachine *sink = BT_MACHINE (bt_sink_machine_new (&cparams, NULL));
+  
   BtWire *wire = bt_wire_new (song, source, sink, NULL);
 
   GST_INFO ("-- act --");
   GList *list = bt_setup_get_wires_by_dst_machine (setup, sink);
 
   GST_INFO ("-- assert --");
-  fail_unless (list != NULL, NULL);
+  ck_assert (list != NULL);
   ck_assert_int_eq (g_list_length (list), 1);
   ck_assert_gobject_eq_and_unref (BT_WIRE (g_list_first (list)->data), wire);
 
@@ -230,17 +268,21 @@ test_bt_setup_wire_add_dst_list (BT_TEST_ARGS)
   g_object_unref (setup);
   BT_TEST_END;
 }
+END_TEST
 
 /*
 * In this example you can see, how we get a source machine back by its type.
 */
-static void
-test_bt_setup_machine_type (BT_TEST_ARGS)
+START_TEST (test_bt_setup_machine_type)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
   BtSetup *setup = BT_SETUP (check_gobject_get_object_property (song, "setup"));
-  BtMachine *source = BT_MACHINE (bt_source_machine_new (song, "src",
+  BtMachineConstructorParams cparams;
+  cparams.id = "src";
+  cparams.song = song;
+  
+  BtMachine *source = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-mono-source", 0, NULL));
 
   GST_INFO ("-- act --");
@@ -248,30 +290,34 @@ test_bt_setup_machine_type (BT_TEST_ARGS)
       bt_setup_get_machine_by_type (setup, BT_TYPE_SOURCE_MACHINE);
 
   GST_INFO ("-- assert --");
-  fail_unless (machine == source, NULL);
+  ck_assert (machine == source);
 
   GST_INFO ("-- cleanup --");
   g_object_unref (machine);
   g_object_unref (setup);
   BT_TEST_END;
 }
+END_TEST
 
 /*
 * In this test case we check the _unique_id function.
 */
-static void
-test_bt_setup_unique_machine_id1 (BT_TEST_ARGS)
+START_TEST (test_bt_setup_unique_machine_id1)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
   BtSetup *setup = BT_SETUP (check_gobject_get_object_property (song, "setup"));
-  bt_source_machine_new (song, "src", "buzztrax-test-mono-source", 0, NULL);
+  BtMachineConstructorParams cparams;
+  cparams.id = "src";
+  cparams.song = song;
+  
+  bt_source_machine_new (&cparams, "buzztrax-test-mono-source", 0, NULL);
 
   GST_INFO ("-- act --");
   gchar *id = bt_setup_get_unique_machine_id (setup, "src");
 
   GST_INFO ("-- assert --");
-  fail_unless (id != NULL, NULL);
+  ck_assert (id != NULL);
   ck_assert_gobject_eq_and_unref (bt_setup_get_machine_by_id (setup, id), NULL);
   ck_assert_str_ne (id, "src");
 
@@ -280,20 +326,26 @@ test_bt_setup_unique_machine_id1 (BT_TEST_ARGS)
   g_object_unref (setup);
   BT_TEST_END;
 }
+END_TEST
 
 /*
 * check if we can connect a src machine to a sink while playing
 */
-static void
-test_bt_setup_dynamic_add_src (BT_TEST_ARGS)
+START_TEST (test_bt_setup_dynamic_add_src)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
   BtSequence *sequence =
       (BtSequence *) check_gobject_get_object_property (song, "sequence");
-  BtMachine *sink = BT_MACHINE (bt_sink_machine_new (song, "master", NULL));
+  
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "master";
+  BtMachine *sink = BT_MACHINE (bt_sink_machine_new (&cparams, NULL));
+  
+  cparams.id = "gen1";
   BtMachine *gen1 =
-      BT_MACHINE (bt_source_machine_new (song, "gen1", "audiotestsrc", 0L,
+      BT_MACHINE (bt_source_machine_new (&cparams, "audiotestsrc", 0L,
           NULL));
   bt_wire_new (song, gen1, sink, NULL);
   GstElement *element1 =
@@ -310,8 +362,10 @@ test_bt_setup_dynamic_add_src (BT_TEST_ARGS)
     check_run_main_loop_until_playing_or_error (song);
     GST_DEBUG ("song plays");
 
+    cparams.id = "gen2";
+  
     BtMachine *gen2 =
-        BT_MACHINE (bt_source_machine_new (song, "gen2", "audiotestsrc", 0L,
+        BT_MACHINE (bt_source_machine_new (&cparams, "audiotestsrc", 0L,
             NULL));
     GstElement *element2 =
         (GstElement *) check_gobject_get_object_property (gen2, "machine");
@@ -325,19 +379,19 @@ test_bt_setup_dynamic_add_src (BT_TEST_ARGS)
     /* stop the song */
     bt_song_stop (song);
   } else {
-    fail ("playing of song failed");
+    ck_assert_msg (FALSE, "playing of song failed");
   }
 
   GST_INFO ("-- cleanup --");
   g_object_unref (sequence);
   BT_TEST_END;
 }
+END_TEST
 
 /*
 * check if we can disconnect a src machine from a sink while playing.
 */
-static void
-test_bt_setup_dynamic_rem_src (BT_TEST_ARGS)
+START_TEST (test_bt_setup_dynamic_rem_src)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -345,12 +399,20 @@ test_bt_setup_dynamic_rem_src (BT_TEST_ARGS)
       (BtSetup *) check_gobject_get_object_property (song, "setup");
   BtSequence *sequence =
       (BtSequence *) check_gobject_get_object_property (song, "sequence");
-  BtMachine *sink = BT_MACHINE (bt_sink_machine_new (song, "master", NULL));
+  
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "master";
+  BtMachine *sink = BT_MACHINE (bt_sink_machine_new (&cparams, NULL));
+  
+  cparams.id = "gen1";
   BtMachine *gen1 =
-      BT_MACHINE (bt_source_machine_new (song, "gen1", "audiotestsrc", 0L,
+      BT_MACHINE (bt_source_machine_new (&cparams, "audiotestsrc", 0L,
           NULL));
+  
+  cparams.id = "gen2";
   BtMachine *gen2 =
-      BT_MACHINE (bt_source_machine_new (song, "gen2", "audiotestsrc", 0L,
+      BT_MACHINE (bt_source_machine_new (&cparams, "audiotestsrc", 0L,
           NULL));
   bt_wire_new (song, gen1, sink, NULL);
   BtWire *wire2 = bt_wire_new (song, gen2, sink, NULL);
@@ -383,7 +445,7 @@ test_bt_setup_dynamic_rem_src (BT_TEST_ARGS)
     /* stop the song */
     bt_song_stop (song);
   } else {
-    fail ("playing of song failed");
+    ck_assert_msg (FALSE, "playing of song failed");
   }
 
   GST_INFO ("-- cleanup --");
@@ -391,20 +453,25 @@ test_bt_setup_dynamic_rem_src (BT_TEST_ARGS)
   g_object_unref (sequence);
   BT_TEST_END;
 }
+END_TEST
 
 /*
  * check if we can connect a processor machine to a src and sink while playing
  */
-static void
-test_bt_setup_dynamic_add_proc (BT_TEST_ARGS)
+START_TEST (test_bt_setup_dynamic_add_proc)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
   BtSequence *sequence =
       (BtSequence *) check_gobject_get_object_property (song, "sequence");
-  BtMachine *sink = BT_MACHINE (bt_sink_machine_new (song, "master", NULL));
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "master";
+  BtMachine *sink = BT_MACHINE (bt_sink_machine_new (&cparams, NULL));
+
+  cparams.id = "gen1";
   BtMachine *gen1 =
-      BT_MACHINE (bt_source_machine_new (song, "gen1", "audiotestsrc", 0L,
+      BT_MACHINE (bt_source_machine_new (&cparams, "audiotestsrc", 0L,
           NULL));
   bt_wire_new (song, gen1, sink, NULL);
   GstElement *element1 =
@@ -422,8 +489,11 @@ test_bt_setup_dynamic_add_proc (BT_TEST_ARGS)
     check_run_main_loop_until_playing_or_error (song);
     GST_DEBUG ("song plays");
 
+  
+    cparams.id = "proc";
+  
     BtMachine *proc =
-        BT_MACHINE (bt_processor_machine_new (song, "proc", "volume", 0, NULL));
+        BT_MACHINE (bt_processor_machine_new (&cparams, "volume", 0, NULL));
     bt_wire_new (song, gen1, proc, NULL);
     bt_wire_new (song, proc, sink, NULL);
 
@@ -432,20 +502,20 @@ test_bt_setup_dynamic_add_proc (BT_TEST_ARGS)
     /* stop the song */
     bt_song_stop (song);
   } else {
-    fail ("playing song failed");
+    ck_assert_msg (FALSE, "playing song failed");
   }
 
   GST_INFO ("-- cleanup --");
   g_object_unref (sequence);;
   BT_TEST_END;
 }
+END_TEST
 
 /*
  * check if we can disconnect a processor machine from a src and sink while
  * playing
  */
-static void
-test_bt_setup_dynamic_rem_proc (BT_TEST_ARGS)
+START_TEST (test_bt_setup_dynamic_rem_proc)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -453,12 +523,20 @@ test_bt_setup_dynamic_rem_proc (BT_TEST_ARGS)
       (BtSetup *) check_gobject_get_object_property (song, "setup");
   BtSequence *sequence =
       (BtSequence *) check_gobject_get_object_property (song, "sequence");
-  BtMachine *sink = BT_MACHINE (bt_sink_machine_new (song, "master", NULL));
+  
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "master";
+  BtMachine *sink = BT_MACHINE (bt_sink_machine_new (&cparams, NULL));
+  
+  cparams.id = "gen1";
   BtMachine *gen1 =
-      BT_MACHINE (bt_source_machine_new (song, "gen1", "audiotestsrc", 0L,
+      BT_MACHINE (bt_source_machine_new (&cparams, "audiotestsrc", 0L,
           NULL));
+  
+  cparams.id = "proc";
   BtMachine *proc =
-      BT_MACHINE (bt_processor_machine_new (song, "proc", "volume", 0, NULL));
+      BT_MACHINE (bt_processor_machine_new (&cparams, "volume", 0, NULL));
   bt_wire_new (song, gen1, sink, NULL);
   BtWire *wire2 = bt_wire_new (song, gen1, proc, NULL);
   BtWire *wire3 = bt_wire_new (song, proc, sink, NULL);
@@ -489,7 +567,7 @@ test_bt_setup_dynamic_rem_proc (BT_TEST_ARGS)
     /* stop the song */
     bt_song_stop (song);
   } else {
-    fail ("playing song failed");
+    ck_assert_msg (FALSE, "playing song failed");
   }
 
   GST_INFO ("-- cleanup --");
@@ -497,6 +575,7 @@ test_bt_setup_dynamic_rem_proc (BT_TEST_ARGS)
   g_object_unref (sequence);
   BT_TEST_END;
 }
+END_TEST
 
 /*
 // We can't implement these below, as songs without atleast 1 src..sink chain

--- a/tests/lib/core/e-sink-bin.c
+++ b/tests/lib/core/e-sink-bin.c
@@ -78,9 +78,15 @@ make_new_song (gint wave)
 {
   BtSequence *sequence =
       (BtSequence *) check_gobject_get_object_property (song, "sequence");
-  BtMachine *sink = BT_MACHINE (bt_sink_machine_new (song, "master", NULL));
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "master";
+  
+  BtMachine *sink = BT_MACHINE (bt_sink_machine_new (&cparams, NULL));
+
+  cparams.id = "gen";
   BtMachine *gen =
-      BT_MACHINE (bt_source_machine_new (song, "gen", "audiotestsrc", 0L,
+      BT_MACHINE (bt_source_machine_new (&cparams, "audiotestsrc", 0L,
           NULL));
   BtParameterGroup *pg = bt_machine_get_global_param_group (gen);
   bt_wire_new (song, gen, sink, NULL);
@@ -331,8 +337,7 @@ run_main_loop_until_eos (void)
 
 //-- tests
 
-static void
-test_bt_sink_bin_new (BT_TEST_ARGS)
+START_TEST (test_bt_sink_bin_new)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -347,10 +352,10 @@ test_bt_sink_bin_new (BT_TEST_ARGS)
   gst_object_unref (bin);
   BT_TEST_END;
 }
+END_TEST
 
 /* test recording (loop test over BtSinkBinRecordFormat */
-static void
-test_bt_sink_bin_record (BT_TEST_ARGS)
+START_TEST (test_bt_sink_bin_record)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -394,10 +399,10 @@ test_bt_sink_bin_record (BT_TEST_ARGS)
   gst_object_unref (sink_bin);
   BT_TEST_END;
 }
+END_TEST
 
 /* test playback + recording, same as above */
-static void
-test_bt_sink_bin_record_and_play (BT_TEST_ARGS)
+START_TEST (test_bt_sink_bin_record_and_play)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -440,10 +445,10 @@ test_bt_sink_bin_record_and_play (BT_TEST_ARGS)
   gst_object_unref (sink_bin);
   BT_TEST_END;
 }
+END_TEST
 
 /* test master volume, using appsink? */
-static void
-test_bt_sink_bin_master_volume (BT_TEST_ARGS)
+START_TEST (test_bt_sink_bin_master_volume)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -480,10 +485,10 @@ test_bt_sink_bin_master_volume (BT_TEST_ARGS)
   g_object_try_unref (machine);
   BT_TEST_END;
 }
+END_TEST
 
 /* insert analyzers */
-static void
-test_bt_sink_bin_analyzers (BT_TEST_ARGS)
+START_TEST (test_bt_sink_bin_analyzers)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -519,6 +524,7 @@ test_bt_sink_bin_analyzers (BT_TEST_ARGS)
   gst_object_unref (sink_bin);
   BT_TEST_END;
 }
+END_TEST
 
 TCase *
 bt_sink_bin_example_case (void)

--- a/tests/lib/core/e-sink-bin.c
+++ b/tests/lib/core/e-sink-bin.c
@@ -346,7 +346,7 @@ START_TEST (test_bt_sink_bin_new)
   GstElement *bin = gst_element_factory_make ("bt-sink-bin", NULL);
 
   GST_INFO ("-- assert --");
-  fail_unless (bin != NULL, NULL);
+  ck_assert (bin != NULL);
 
   GST_INFO ("-- cleanup --");
   gst_object_unref (bin);

--- a/tests/lib/core/e-sink-machine.c
+++ b/tests/lib/core/e-sink-machine.c
@@ -84,8 +84,7 @@ get_sink_element (GstBin * bin)
 
 //-- tests
 
-static void
-test_bt_sink_machine_new (BT_TEST_ARGS)
+START_TEST (test_bt_sink_machine_new)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -93,29 +92,37 @@ test_bt_sink_machine_new (BT_TEST_ARGS)
 
   GST_INFO ("-- act --");
   GError *err = NULL;
-  BtSinkMachine *machine = bt_sink_machine_new (song, "master", &err);
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "master";
+  
+  BtSinkMachine *machine = bt_sink_machine_new (&cparams, &err);
 
   GST_INFO ("-- assert --");
-  fail_unless (machine != NULL, NULL);
-  fail_unless (err == NULL, NULL);
+  ck_assert (machine != NULL);
+  ck_assert (err == NULL);
 
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_sink_machine_def_patterns (BT_TEST_ARGS)
+START_TEST (test_bt_sink_machine_def_patterns)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
   g_object_set (settings, "audiosink", "fakesink", NULL);
-  BtSinkMachine *machine = bt_sink_machine_new (song, "master", NULL);
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "master";
+  
+  BtSinkMachine *machine = bt_sink_machine_new (&cparams, NULL);
 
   GST_INFO ("-- act --");
   GList *list = (GList *) check_gobject_get_ptr_property (machine, "patterns");
 
   GST_INFO ("-- assert --");
-  fail_unless (list != NULL, NULL);
+  ck_assert (list != NULL);
   ck_assert_int_eq (g_list_length (list), 2);   /* break+mute */
 
   GST_INFO ("-- cleanup --");
@@ -123,14 +130,18 @@ test_bt_sink_machine_def_patterns (BT_TEST_ARGS)
   g_list_free (list);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_sink_machine_pattern (BT_TEST_ARGS)
+START_TEST (test_bt_sink_machine_pattern)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
   g_object_set (settings, "audiosink", "fakesink", NULL);
-  BtSinkMachine *machine = bt_sink_machine_new (song, "master", NULL);
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "master";
+  
+  BtSinkMachine *machine = bt_sink_machine_new (&cparams, NULL);
 
   GST_INFO ("-- act --");
   BtCmdPattern *pattern =
@@ -138,21 +149,25 @@ test_bt_sink_machine_pattern (BT_TEST_ARGS)
       BT_MACHINE (machine));
 
   GST_INFO ("-- assert --");
-  fail_unless (pattern != NULL, NULL);
-  ck_assert_gobject_gulong_eq (pattern, "voices", 0);
+  ck_assert (pattern != NULL);
+  ck_assert_gobject_gulong_eq (pattern, "voices", 0L);
 
   GST_INFO ("-- cleanup --");
   g_object_unref (pattern);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_sink_machine_pattern_by_id (BT_TEST_ARGS)
+START_TEST (test_bt_sink_machine_pattern_by_id)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
   g_object_set (settings, "audiosink", "fakesink", NULL);
-  BtSinkMachine *machine = bt_sink_machine_new (song, "master", NULL);
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "master";
+  
+  BtSinkMachine *machine = bt_sink_machine_new (&cparams, NULL);
 
   GST_INFO ("-- act --");
   BtCmdPattern *pattern =
@@ -167,33 +182,41 @@ test_bt_sink_machine_pattern_by_id (BT_TEST_ARGS)
   g_object_unref (pattern);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_sink_machine_pattern_by_index (BT_TEST_ARGS)
+START_TEST (test_bt_sink_machine_pattern_by_index)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
-  BtSinkMachine *machine = bt_sink_machine_new (song, "master", NULL);
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "master";
+  
+  BtSinkMachine *machine = bt_sink_machine_new (&cparams, NULL);
 
   GST_INFO ("-- act --");
   BtCmdPattern *pattern = bt_machine_get_pattern_by_index (BT_MACHINE (machine),
       BT_SINK_MACHINE_PATTERN_INDEX_MUTE);
 
   GST_INFO ("-- assert --");
-  fail_unless (pattern != NULL, NULL);
+  ck_assert (pattern != NULL);
 
   GST_INFO ("-- cleanup --");
   g_object_unref (pattern);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_sink_machine_pattern_by_list (BT_TEST_ARGS)
+START_TEST (test_bt_sink_machine_pattern_by_list)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
   g_object_set (settings, "audiosink", "fakesink", NULL);
-  BtSinkMachine *machine = bt_sink_machine_new (song, "master", NULL);
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "master";
+  
+  BtSinkMachine *machine = bt_sink_machine_new (&cparams, NULL);
   BtCmdPattern *pattern =
       (BtCmdPattern *) bt_pattern_new (song, "pattern-name", 8L,
       BT_MACHINE (machine));
@@ -203,7 +226,7 @@ test_bt_sink_machine_pattern_by_list (BT_TEST_ARGS)
   GList *node = g_list_last (list);
 
   GST_INFO ("-- assert --");
-  fail_unless (node->data == pattern, NULL);
+  ck_assert (node->data == pattern);
 
   GST_INFO ("-- cleanup --");
   g_list_foreach (list, (GFunc) g_object_unref, NULL);
@@ -211,9 +234,9 @@ test_bt_sink_machine_pattern_by_list (BT_TEST_ARGS)
   g_object_unref (pattern);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_sink_machine_default (BT_TEST_ARGS)
+START_TEST (test_bt_sink_machine_default)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -221,18 +244,22 @@ test_bt_sink_machine_default (BT_TEST_ARGS)
 
   GST_INFO ("-- act --");
   GError *err = NULL;
-  BtSinkMachine *machine = bt_sink_machine_new (song, "master", &err);
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "master";
+  
+  BtSinkMachine *machine = bt_sink_machine_new (&cparams, &err);
 
   GST_INFO ("-- assert --");
-  fail_unless (machine != NULL, NULL);
-  fail_unless (err == NULL, NULL);
+  ck_assert (machine != NULL);
+  ck_assert (err == NULL);
 
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_sink_machine_fallback (BT_TEST_ARGS)
+START_TEST (test_bt_sink_machine_fallback)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -247,22 +274,30 @@ test_bt_sink_machine_fallback (BT_TEST_ARGS)
 
   GST_INFO ("-- act --");
   GError *err = NULL;
-  BtSinkMachine *machine = bt_sink_machine_new (song, "master", &err);
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "master";
+  
+  BtSinkMachine *machine = bt_sink_machine_new (&cparams, &err);
 
   GST_INFO ("-- assert --");
-  fail_unless (machine != NULL, NULL);
-  fail_unless (err == NULL, NULL);
+  ck_assert (machine != NULL);
+  ck_assert (err == NULL);
 
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_sink_machine_actual_sink (BT_TEST_ARGS)
+START_TEST (test_bt_sink_machine_actual_sink)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
-  BtSinkMachine *machine = bt_sink_machine_new (song, "master", NULL);
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "master";
+  
+  BtSinkMachine *machine = bt_sink_machine_new (&cparams, NULL);
 
   GST_INFO ("-- act --");
   GstElement *sink_bin =
@@ -271,26 +306,31 @@ test_bt_sink_machine_actual_sink (BT_TEST_ARGS)
   GstElement *sink = get_sink_element ((GstBin *) sink_bin);
 
   GST_INFO ("-- assert --");
-  fail_unless (sink != NULL, NULL);
+  ck_assert (sink != NULL);
 
   GST_INFO ("-- cleanup --");
   gst_object_unref (sink_bin);
   BT_TEST_END;
 }
+END_TEST
 
 /* the parameter index _i is 2bits for latency, 2bits for bpm, 2 bits for tpb */
-static void
-test_bt_sink_machine_latency (BT_TEST_ARGS)
+START_TEST (test_bt_sink_machine_latency)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
   BtSongInfo *song_info =
       BT_SONG_INFO (check_gobject_get_object_property (song, "song-info"));
-  BtMachine *gen = BT_MACHINE (bt_source_machine_new (song, "gen",
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "gen";
+  BtMachine *gen = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-mono-source", 0L, NULL));
   BtTestMonoSource *src =
       (BtTestMonoSource *) check_gobject_get_object_property (gen, "machine");
-  BtMachine *master = BT_MACHINE (bt_sink_machine_new (song, "master", NULL));
+  cparams.id = "master";
+  
+  BtMachine *master = BT_MACHINE (bt_sink_machine_new (&cparams, NULL));
   GstElement *sink_bin =
       GST_ELEMENT (check_gobject_get_object_property (master, "machine"));
   bt_wire_new (song, gen, master, NULL);
@@ -300,7 +340,7 @@ test_bt_sink_machine_latency (BT_TEST_ARGS)
     GST_WARNING ("no sink or not AudioBaseSink");
     goto Cleanup;
   }
-  guint latency = 20 + 20 * (_i & 0x3);
+  gulong latency = 20 + 20 * (_i & 0x3);
   gulong bpm = 80 + 20 * ((_i >> 2) & 0x3);
   gulong tpb = 4 + 2 * ((_i >> 4) & 0x3);
 
@@ -309,7 +349,7 @@ test_bt_sink_machine_latency (BT_TEST_ARGS)
   // assert the resulting latency-time properties on the audio_sink
   g_object_set (settings, "latency", latency, NULL);
   g_object_set (song_info, "bpm", bpm, "tpb", tpb, NULL);
-  guint st = src->stpb, c_bpm = src->bpm, c_tpb = src->tpb;
+  gulong st = src->stpb, c_bpm = src->bpm, c_tpb = src->tpb;
 
   GST_INFO ("-- assert --");
   gint64 latency_time, c_latency_time;
@@ -317,10 +357,10 @@ test_bt_sink_machine_latency (BT_TEST_ARGS)
   latency_time = GST_TIME_AS_USECONDS ((GST_SECOND * 60) / (bpm * tpb * st));
 
   GST_INFO_OBJECT (sink,
-      "bpm=%3lu=%3u, tpb=%lu=%u, stpb=%2u, target-latency=%2u , latency-time=%6"
+      "bpm=%3lu=%3lu, tpb=%lu=%lu, stpb=%2lu, target-latency=%2lu , latency-time=%6"
       G_GINT64_FORMAT "=%6" G_GINT64_FORMAT ", delta=%+4" G_GINT64_FORMAT, bpm,
       c_bpm, tpb, c_tpb, st, latency, latency_time, c_latency_time,
-      (latency_time - ((gint) latency * 1000)) / 1000);
+      (latency_time - (latency * 1000)) / 1000);
 
   ck_assert_ulong_eq (c_bpm, bpm);
   ck_assert_ulong_eq (c_tpb, tpb);
@@ -332,13 +372,17 @@ Cleanup:
   g_object_unref (song_info);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_sink_machine_pretty_name (BT_TEST_ARGS)
+START_TEST (test_bt_sink_machine_pretty_name)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
-  BtSinkMachine *machine = bt_sink_machine_new (song, "master", NULL);
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "master";
+  
+  BtSinkMachine *machine = bt_sink_machine_new (&cparams, NULL);
 
   GST_INFO ("-- act --");
 
@@ -348,6 +392,7 @@ test_bt_sink_machine_pretty_name (BT_TEST_ARGS)
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
 
 TCase *

--- a/tests/lib/core/e-song-info.c
+++ b/tests/lib/core/e-song-info.c
@@ -52,8 +52,7 @@ case_teardown (void)
 
 //-- tests
 
-static void
-test_bt_song_info_date_stamps (BT_TEST_ARGS)
+START_TEST (test_bt_song_info_date_stamps)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -72,10 +71,10 @@ test_bt_song_info_date_stamps (BT_TEST_ARGS)
   g_object_unref (song_info);
   BT_TEST_END;
 }
+END_TEST
 
 /* Test changing the tempo */
-static void
-test_bt_song_info_update_bpm (BT_TEST_ARGS)
+START_TEST (test_bt_song_info_update_bpm)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -96,9 +95,9 @@ test_bt_song_info_update_bpm (BT_TEST_ARGS)
   g_object_unref (song_info);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_song_info_update_tpb (BT_TEST_ARGS)
+START_TEST (test_bt_song_info_update_tpb)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -119,10 +118,10 @@ test_bt_song_info_update_tpb (BT_TEST_ARGS)
   g_object_unref (song_info);
   BT_TEST_END;
 }
+END_TEST
 
 
-static void
-test_bt_song_info_seconds_since_last_saved (BT_TEST_ARGS)
+START_TEST (test_bt_song_info_seconds_since_last_saved)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -141,9 +140,9 @@ test_bt_song_info_seconds_since_last_saved (BT_TEST_ARGS)
   g_object_unref (song_info);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_song_info_tick_to_time (BT_TEST_ARGS)
+START_TEST (test_bt_song_info_tick_to_time)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -161,6 +160,7 @@ test_bt_song_info_tick_to_time (BT_TEST_ARGS)
   g_object_unref (song_info);
   BT_TEST_END;
 }
+END_TEST
 
 TCase *
 bt_song_info_example_case (void)
@@ -176,3 +176,4 @@ bt_song_info_example_case (void)
   tcase_add_unchecked_fixture (tc, case_setup, case_teardown);
   return tc;
 }
+

--- a/tests/lib/core/e-song-info.c
+++ b/tests/lib/core/e-song-info.c
@@ -63,7 +63,7 @@ START_TEST (test_bt_song_info_date_stamps)
   gchar *create_dts = check_gobject_get_str_property (song_info, "create-dts");
 
   GST_INFO ("-- assert --");
-  fail_unless (create_dts != NULL, NULL);
+  ck_assert (create_dts != NULL);
   ck_assert_gobject_str_eq (song_info, "change-dts", create_dts);
 
   GST_INFO ("-- cleanup --");

--- a/tests/lib/core/e-song-io-native.c
+++ b/tests/lib/core/e-song-io-native.c
@@ -272,7 +272,7 @@ START_TEST (test_bt_song_io_native_new)
       bt_song_io_from_file (check_get_test_song_path ("simple2.xml"), NULL);
 
   GST_INFO ("-- assert --");
-  fail_unless (song_io != NULL, NULL);
+  ck_assert (song_io != NULL);
 
   GST_INFO ("-- cleanup --");
   ck_g_object_final_unref (song_io);
@@ -291,7 +291,7 @@ START_TEST (test_bt_song_io_native_formats)
   BtSongIO *song_io = bt_song_io_from_file (song_path, NULL);
 
   GST_INFO ("-- assert --");
-  fail_unless (song_io != NULL, NULL);
+  ck_assert (song_io != NULL);
 
   GST_INFO ("-- cleanup --");
   ck_g_object_final_unref (song_io);
@@ -310,7 +310,7 @@ START_TEST (test_bt_song_io_native_load)
   GST_INFO ("-- act --");
 
   GST_INFO ("-- assert --");
-  fail_unless (bt_song_io_load (song_io, song, NULL) == TRUE, NULL);
+  ck_assert (bt_song_io_load (song_io, song, NULL) == TRUE);
 
   GST_INFO ("-- cleanup --");
   ck_g_object_final_unref (song_io);
@@ -497,7 +497,7 @@ START_TEST (test_bt_song_io_write_song)
   GST_INFO ("-- act --");
   BtSongIO *song_io = bt_song_io_from_file (song_path, NULL);
   gboolean res = bt_song_io_save (song_io, song, NULL);
-  fail_unless (res == TRUE, NULL);
+  ck_assert (res == TRUE);
 
   ck_g_object_final_unref (song_io);
   ck_g_object_final_unref (song);
@@ -507,7 +507,7 @@ START_TEST (test_bt_song_io_write_song)
   GST_INFO ("-- assert --");
   song_io = bt_song_io_from_file (song_path, NULL);
   res = bt_song_io_load (song_io, song, NULL);
-  fail_unless (res == TRUE, NULL);
+  ck_assert (res == TRUE);
 
   GST_INFO ("-- cleanup --");
   ck_g_object_final_unref (song_io);
@@ -533,7 +533,7 @@ START_TEST (test_bt_song_io_native_load_legacy_0_7)
   BtMachine *machine = bt_setup_get_machine_by_id (setup, "beep");
   BtCmdPattern *pattern1 = bt_machine_get_pattern_by_name (machine, "beeps");
   BtCmdPattern *pattern2 = bt_sequence_get_pattern (sequence, 0, 0);
-  fail_unless (pattern1 == pattern2, NULL);
+  ck_assert (pattern1 == pattern2);
 
   GST_INFO ("-- cleanup --");
   g_object_unref (pattern1);

--- a/tests/lib/core/e-song-io-native.c
+++ b/tests/lib/core/e-song-io-native.c
@@ -165,8 +165,14 @@ make_song_normal (void)
       BT_SEQUENCE (check_gobject_get_object_property (song, "sequence"));
   g_object_set (sequence, "length", 8L, NULL);
 
-  BtMachine *sink = BT_MACHINE (bt_sink_machine_new (song, "master", NULL));
-  BtMachine *gen1 = BT_MACHINE (bt_source_machine_new (song, "gen-m",
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "master";
+  
+  BtMachine *sink = BT_MACHINE (bt_sink_machine_new (&cparams, NULL));
+
+  cparams.id = "gen-m";
+  BtMachine *gen1 = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-mono-source", 0L, NULL));
   BtWire *wire = bt_wire_new (song, gen1, sink, NULL);
   BtPattern *pat_gen1 = bt_pattern_new (song, "melo", 8L, gen1);
@@ -176,7 +182,8 @@ make_song_normal (void)
 
   bt_pattern_set_wire_event (pat_gen1, 0, wire, 0, "100");
 
-  BtMachine *gen2 = BT_MACHINE (bt_source_machine_new (song, "gen-p",
+  cparams.id = "gen-p";
+  BtMachine *gen2 = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-poly-source", 1L, NULL));
   bt_wire_new (song, gen2, sink, NULL);
   BtPattern *pat_gen2 = bt_pattern_new (song, "melo", 8L, gen2);
@@ -203,8 +210,14 @@ make_ext_data_uri (const gchar * file_name)
 static void
 make_song_with_externals (void)
 {
-  BtMachine *sink = BT_MACHINE (bt_sink_machine_new (song, "master", NULL));
-  BtMachine *gen = BT_MACHINE (bt_source_machine_new (song, "gen",
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "master";
+  
+  BtMachine *sink = BT_MACHINE (bt_sink_machine_new (&cparams, NULL));
+
+  cparams.id = "gen";
+  BtMachine *gen = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-mono-source", 0L, NULL));
   bt_wire_new (song, gen, sink, NULL);
   BtPattern *pattern = bt_pattern_new (song, "pattern-name", 8L, gen);
@@ -222,8 +235,14 @@ make_song_with_externals (void)
 static void
 make_song_with_ic_binding (void)
 {
-  BtMachine *sink = BT_MACHINE (bt_sink_machine_new (song, "master", NULL));
-  BtMachine *gen = BT_MACHINE (bt_source_machine_new (song, "gen",
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "master";
+  
+  BtMachine *sink = BT_MACHINE (bt_sink_machine_new (&cparams, NULL));
+
+  cparams.id = "gen";
+  BtMachine *gen = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-mono-source", 0L, NULL));
   bt_wire_new (song, gen, sink, NULL);
 
@@ -243,8 +262,7 @@ make_song_with_ic_binding (void)
 
 //-- tests
 
-static void
-test_bt_song_io_native_new (BT_TEST_ARGS)
+START_TEST (test_bt_song_io_native_new)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -260,9 +278,9 @@ test_bt_song_io_native_new (BT_TEST_ARGS)
   ck_g_object_final_unref (song_io);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_song_io_native_formats (BT_TEST_ARGS)
+START_TEST (test_bt_song_io_native_formats)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -280,9 +298,9 @@ test_bt_song_io_native_formats (BT_TEST_ARGS)
   g_free (song_path);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_song_io_native_load (BT_TEST_ARGS)
+START_TEST (test_bt_song_io_native_load)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -298,9 +316,9 @@ test_bt_song_io_native_load (BT_TEST_ARGS)
   ck_g_object_final_unref (song_io);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_song_io_native_core_refcounts (BT_TEST_ARGS)
+START_TEST (test_bt_song_io_native_core_refcounts)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -318,9 +336,9 @@ test_bt_song_io_native_core_refcounts (BT_TEST_ARGS)
   ck_g_object_final_unref (song_io);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_song_io_native_setup_refcounts_0 (BT_TEST_ARGS)
+START_TEST (test_bt_song_io_native_setup_refcounts_0)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -342,9 +360,9 @@ test_bt_song_io_native_setup_refcounts_0 (BT_TEST_ARGS)
   ck_g_object_final_unref (song_io);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_song_io_native_setup_refcounts_1 (BT_TEST_ARGS)
+START_TEST (test_bt_song_io_native_setup_refcounts_1)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -377,9 +395,9 @@ test_bt_song_io_native_setup_refcounts_1 (BT_TEST_ARGS)
   ck_g_object_final_unref (song_io);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_song_io_native_setup_refcounts_2 (BT_TEST_ARGS)
+START_TEST (test_bt_song_io_native_setup_refcounts_2)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -416,9 +434,9 @@ test_bt_song_io_native_setup_refcounts_2 (BT_TEST_ARGS)
   ck_g_object_final_unref (song_io);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_song_io_native_song_refcounts (BT_TEST_ARGS)
+START_TEST (test_bt_song_io_native_song_refcounts)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -446,9 +464,9 @@ test_bt_song_io_native_song_refcounts (BT_TEST_ARGS)
   gst_object_unref (bin);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_song_io_write_song (BT_TEST_ARGS)
+START_TEST (test_bt_song_io_write_song)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -496,9 +514,9 @@ test_bt_song_io_write_song (BT_TEST_ARGS)
   g_free (song_path);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_song_io_native_load_legacy_0_7 (BT_TEST_ARGS)
+START_TEST (test_bt_song_io_native_load_legacy_0_7)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -526,6 +544,7 @@ test_bt_song_io_native_load_legacy_0_7 (BT_TEST_ARGS)
   ck_g_object_final_unref (song_io);
   BT_TEST_END;
 }
+END_TEST
 
 TCase *
 bt_song_io_native_example_case (void)

--- a/tests/lib/core/e-song-io.c
+++ b/tests/lib/core/e-song-io.c
@@ -46,8 +46,7 @@ case_teardown (void)
 
 //-- tests
 
-static void
-test_bt_song_io_module_info (BT_TEST_ARGS)
+START_TEST (test_bt_song_io_module_info)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -56,14 +55,14 @@ test_bt_song_io_module_info (BT_TEST_ARGS)
   const GList *mi = bt_song_io_get_module_info_list ();
 
   GST_INFO ("-- assert --");
-  fail_unless (mi != NULL, NULL);
+  ck_assert (mi != NULL);
 
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_song_io_file (BT_TEST_ARGS)
+START_TEST (test_bt_song_io_file)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -73,16 +72,16 @@ test_bt_song_io_file (BT_TEST_ARGS)
       bt_song_io_from_file (check_get_test_song_path ("simple2.xml"), NULL);
 
   GST_INFO ("-- assert --");
-  fail_unless (song_io != NULL, NULL);
-  fail_unless (BT_IS_SONG_IO_NATIVE (song_io), NULL);
+  ck_assert (song_io != NULL);
+  ck_assert (BT_IS_SONG_IO_NATIVE (song_io));
 
   GST_INFO ("-- cleanup --");
   ck_g_object_final_unref (song_io);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_song_io_data (BT_TEST_ARGS)
+START_TEST (test_bt_song_io_data)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -91,13 +90,14 @@ test_bt_song_io_data (BT_TEST_ARGS)
   BtSongIO *song_io = bt_song_io_from_data (NULL, 0, "audio/x-bzt-xml", NULL);
 
   GST_INFO ("-- assert --");
-  fail_unless (song_io != NULL, NULL);
-  fail_unless (BT_IS_SONG_IO_NATIVE (song_io), NULL);
+  ck_assert (song_io != NULL);
+  ck_assert (BT_IS_SONG_IO_NATIVE (song_io));
 
   GST_INFO ("-- cleanup --");
   ck_g_object_final_unref (song_io);
   BT_TEST_END;
 }
+END_TEST
 
 TCase *
 bt_song_io_example_case (void)

--- a/tests/lib/core/e-song.c
+++ b/tests/lib/core/e-song.c
@@ -64,9 +64,15 @@ make_new_song (void)
       (BtSequence *) check_gobject_get_object_property (song, "sequence");
   BtSongInfo *song_info =
       BT_SONG_INFO (check_gobject_get_object_property (song, "song-info"));
-  BtMachine *sink = BT_MACHINE (bt_sink_machine_new (song, "master", NULL));
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "master";
+  
+  BtMachine *sink = BT_MACHINE (bt_sink_machine_new (&cparams, NULL));
+
+  cparams.id = "gen";
   BtMachine *gen =
-      BT_MACHINE (bt_source_machine_new (song, "gen", "audiotestsrc", 0L,
+      BT_MACHINE (bt_source_machine_new (&cparams, "audiotestsrc", 0L,
           NULL));
   bt_wire_new (song, gen, sink, NULL);
   BtPattern *pattern = bt_pattern_new (song, "pattern-name", 8L, gen);
@@ -102,8 +108,7 @@ on_song_is_playing_notify (const BtSong * song, GParamSpec * arg,
 //-- tests
 
 // test if the default constructor works as expected
-static void
-test_bt_song_new (BT_TEST_ARGS)
+START_TEST (test_bt_song_new)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -112,18 +117,18 @@ test_bt_song_new (BT_TEST_ARGS)
   BtSong *song = bt_song_new (app);
 
   GST_INFO ("-- assert --");
-  fail_unless (song != NULL, NULL);
+  ck_assert (song != NULL);
   ck_assert_gobject_object_eq (song, "master", NULL);
 
   GST_INFO ("-- cleanup --");
   ck_g_object_final_unref (song);
   BT_TEST_END;
 }
+END_TEST
 
 // test, if a newly created song contains setup, sequence, song-info and
 // wavetable and they point back to the song
-static void
-test_bt_song_members (BT_TEST_ARGS)
+START_TEST (test_bt_song_members)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -141,13 +146,13 @@ test_bt_song_members (BT_TEST_ARGS)
 
   GST_INFO ("-- assert --");
   ck_assert_gobject_object_eq (song, "app", app);
-  fail_unless (setup != NULL, NULL);
+  ck_assert (setup != NULL);
   ck_assert_gobject_object_eq (setup, "song", song);
-  fail_unless (sequence != NULL, NULL);
+  ck_assert (sequence != NULL);
   ck_assert_gobject_object_eq (sequence, "song", song);
-  fail_unless (songinfo != NULL, NULL);
+  ck_assert (songinfo != NULL);
   ck_assert_gobject_object_eq (songinfo, "song", song);
-  fail_unless (wavetable != NULL, NULL);
+  ck_assert (wavetable != NULL);
   ck_assert_gobject_object_eq (wavetable, "song", song);
 
   GST_INFO ("-- cleanup --");
@@ -158,9 +163,9 @@ test_bt_song_members (BT_TEST_ARGS)
   ck_g_object_final_unref (song);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_song_master (BT_TEST_ARGS)
+START_TEST (test_bt_song_master)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -173,10 +178,10 @@ test_bt_song_master (BT_TEST_ARGS)
   ck_g_object_final_unref (song);
   BT_TEST_END;
 }
+END_TEST
 
 // test if the song play routine works without failure
-static void
-test_bt_song_play_single (BT_TEST_ARGS)
+START_TEST (test_bt_song_play_single)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -189,7 +194,7 @@ test_bt_song_play_single (BT_TEST_ARGS)
   check_run_main_loop_until_playing_or_error (song);
 
   GST_INFO ("-- assert --");
-  fail_unless (play_signal_invoked, NULL);
+  ck_assert (play_signal_invoked);
   ck_assert_gobject_gboolean_eq (song, "is-playing", TRUE);
 
   GST_INFO ("-- act --");
@@ -203,10 +208,10 @@ test_bt_song_play_single (BT_TEST_ARGS)
   ck_g_object_final_unref (song);
   BT_TEST_END;
 }
+END_TEST
 
 // play, wait a little, stop, play again
-static void
-test_bt_song_play_twice (BT_TEST_ARGS)
+START_TEST (test_bt_song_play_twice)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -221,19 +226,19 @@ test_bt_song_play_twice (BT_TEST_ARGS)
   check_run_main_loop_for_usec (G_USEC_PER_SEC / 10);
 
   /* act && assert */
-  fail_unless (bt_song_play (song), NULL);
+  ck_assert (bt_song_play (song));
   check_run_main_loop_until_playing_or_error (song);
-  fail_unless (play_signal_invoked, NULL);
+  ck_assert (play_signal_invoked);
 
   GST_INFO ("-- cleanup --");
   bt_song_stop (song);
   ck_g_object_final_unref (song);
   BT_TEST_END;
 }
+END_TEST
 
 // load a new song, play, change audiosink to fakesink
-static void
-test_bt_song_play_and_change_sink (BT_TEST_ARGS)
+START_TEST (test_bt_song_play_and_change_sink)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -254,10 +259,10 @@ test_bt_song_play_and_change_sink (BT_TEST_ARGS)
   ck_g_object_final_unref (song);
   BT_TEST_END;
 }
+END_TEST
 
 // change audiosink to NULL, load and play a song
-static void
-test_bt_song_play_fallback_sink (BT_TEST_ARGS)
+START_TEST (test_bt_song_play_fallback_sink)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -272,17 +277,17 @@ test_bt_song_play_fallback_sink (BT_TEST_ARGS)
   BtSong *song = make_new_song ();
 
   GST_INFO ("-- act --");
-  fail_unless (bt_song_play (song), NULL);
+  ck_assert (bt_song_play (song));
 
   GST_INFO ("-- cleanup --");
   bt_song_stop (song);
   ck_g_object_final_unref (song);
   BT_TEST_END;
 }
+END_TEST
 
 // test the idle looper
-static void
-test_bt_song_idle1 (BT_TEST_ARGS)
+START_TEST (test_bt_song_idle1)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -300,10 +305,10 @@ test_bt_song_idle1 (BT_TEST_ARGS)
   ck_g_object_final_unref (song);
   BT_TEST_END;
 }
+END_TEST
 
 // test the idle looper and playing transition
-static void
-test_bt_song_idle2 (BT_TEST_ARGS)
+START_TEST (test_bt_song_idle2)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -335,25 +340,32 @@ test_bt_song_idle2 (BT_TEST_ARGS)
   ck_g_object_final_unref (song);
   BT_TEST_END;
 }
+END_TEST
 
 /*
  * check if we can connect two sine machines to one sink. Also try to play after
  * connecting the machines.
  */
-static void
-test_bt_song_play_two_sources (BT_TEST_ARGS)
+START_TEST (test_bt_song_play_two_sources)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
   BtSong *song = bt_song_new (app);
   BtSequence *sequence =
       (BtSequence *) check_gobject_get_object_property (song, "sequence");
-  BtMachine *sink = BT_MACHINE (bt_sink_machine_new (song, "master", NULL));
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "master";
+  
+  BtMachine *sink = BT_MACHINE (bt_sink_machine_new (&cparams, NULL));
+
+  cparams.id = "gen1";
   BtMachine *gen1 =
-      BT_MACHINE (bt_source_machine_new (song, "gen1", "audiotestsrc", 0L,
+      BT_MACHINE (bt_source_machine_new (&cparams, "audiotestsrc", 0L,
           NULL));
+  cparams.id = "gen2";
   BtMachine *gen2 =
-      BT_MACHINE (bt_source_machine_new (song, "gen2", "audiotestsrc", 0L,
+      BT_MACHINE (bt_source_machine_new (&cparams, "audiotestsrc", 0L,
           NULL));
   bt_wire_new (song, gen1, sink, NULL);
   bt_wire_new (song, gen2, sink, NULL);
@@ -376,7 +388,7 @@ test_bt_song_play_two_sources (BT_TEST_ARGS)
     /* stop the song */
     bt_song_stop (song);
   } else {
-    fail ("playing song failed");
+    ck_assert_msg (FALSE, "playing song failed");
   }
 
   GST_INFO ("-- cleanup --");
@@ -386,28 +398,36 @@ test_bt_song_play_two_sources (BT_TEST_ARGS)
   ck_g_object_final_unref (song);
   BT_TEST_END;
 }
+END_TEST
 
 /*
  * check if we can connect two sine machines to one effect and this to the
  * sink. Also try to start play after connecting the machines.
  */
-static void
-test_bt_song_play_two_sources_and_one_fx (BT_TEST_ARGS)
+START_TEST (test_bt_song_play_two_sources_and_one_fx)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
   BtSong *song = bt_song_new (app);
   BtSequence *sequence =
       (BtSequence *) check_gobject_get_object_property (song, "sequence");
-  BtMachine *sink = BT_MACHINE (bt_sink_machine_new (song, "master", NULL));
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "master";
+  
+  BtMachine *sink = BT_MACHINE (bt_sink_machine_new (&cparams, NULL));
+
+  cparams.id = "gen1";
   BtMachine *gen1 =
-      BT_MACHINE (bt_source_machine_new (song, "gen1", "audiotestsrc", 0L,
+      BT_MACHINE (bt_source_machine_new (&cparams, "audiotestsrc", 0L,
           NULL));
+  cparams.id = "gen2";
   BtMachine *gen2 =
-      BT_MACHINE (bt_source_machine_new (song, "gen2", "audiotestsrc", 0L,
+      BT_MACHINE (bt_source_machine_new (&cparams, "audiotestsrc", 0L,
           NULL));
+  cparams.id = "proc";
   BtMachine *proc =
-      BT_MACHINE (bt_processor_machine_new (song, "proc", "volume", 0, NULL));
+      BT_MACHINE (bt_processor_machine_new (&cparams, "volume", 0, NULL));
   bt_wire_new (song, gen1, proc, NULL);
   bt_wire_new (song, gen2, proc, NULL);
   bt_wire_new (song, proc, sink, NULL);
@@ -430,7 +450,7 @@ test_bt_song_play_two_sources_and_one_fx (BT_TEST_ARGS)
     /* stop the song */
     bt_song_stop (song);
   } else {
-    fail ("playing song failed");
+    ck_assert_msg (FALSE, "playing song failed");
   }
 
   gst_object_unref (element1);
@@ -439,13 +459,13 @@ test_bt_song_play_two_sources_and_one_fx (BT_TEST_ARGS)
   ck_g_object_final_unref (song);
   BT_TEST_END;
 }
+END_TEST
 
 /*
  * check if we can connect two sine machines to one sink, then play() and
  * stop(). After stopping remove one machine and play again.
  */
-static void
-test_bt_song_play_change_replay (BT_TEST_ARGS)
+START_TEST (test_bt_song_play_change_replay)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -454,12 +474,19 @@ test_bt_song_play_change_replay (BT_TEST_ARGS)
       (BtSetup *) check_gobject_get_object_property (song, "setup");
   BtSequence *sequence =
       (BtSequence *) check_gobject_get_object_property (song, "sequence");
-  BtMachine *sink = BT_MACHINE (bt_sink_machine_new (song, "master", NULL));
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "master";
+  
+  BtMachine *sink = BT_MACHINE (bt_sink_machine_new (&cparams, NULL));
+
+  cparams.id = "gen1";
   BtMachine *gen1 =
-      BT_MACHINE (bt_source_machine_new (song, "gen1", "audiotestsrc", 0L,
+      BT_MACHINE (bt_source_machine_new (&cparams, "audiotestsrc", 0L,
           NULL));
+  cparams.id = "gen2";
   BtMachine *gen2 =
-      BT_MACHINE (bt_source_machine_new (song, "gen2", "audiotestsrc", 0L,
+      BT_MACHINE (bt_source_machine_new (&cparams, "audiotestsrc", 0L,
           NULL));
   bt_wire_new (song, gen1, sink, NULL);
   BtWire *wire2 = bt_wire_new (song, gen2, sink, NULL);
@@ -482,12 +509,12 @@ test_bt_song_play_change_replay (BT_TEST_ARGS)
     /* stop the song */
     bt_song_stop (song);
   } else {
-    fail ("playing of network song failed");
+    ck_assert_msg (FALSE, "playing of network song failed");
   }
 
   /* remove one machine */
   bt_setup_remove_wire (setup, wire2);
-  fail_unless (bt_sequence_remove_track_by_machine (sequence, gen2), NULL);
+  ck_assert (bt_sequence_remove_track_by_machine (sequence, gen2));
   bt_setup_remove_machine (setup, gen2);
   mark_point ();
 
@@ -498,7 +525,7 @@ test_bt_song_play_change_replay (BT_TEST_ARGS)
     /* stop the song */
     bt_song_stop (song);
   } else {
-    fail ("playing song failed again");
+    ck_assert_msg (FALSE, "playing song failed again");
   }
 
   GST_INFO ("-- cleanup --");
@@ -509,9 +536,9 @@ test_bt_song_play_change_replay (BT_TEST_ARGS)
   ck_g_object_final_unref (song);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_song_play_pos (BT_TEST_ARGS)
+START_TEST (test_bt_song_play_pos)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -531,9 +558,9 @@ test_bt_song_play_pos (BT_TEST_ARGS)
   ck_g_object_final_unref (song);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_song_play_pos_on_eos (BT_TEST_ARGS)
+START_TEST (test_bt_song_play_pos_on_eos)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -552,9 +579,9 @@ test_bt_song_play_pos_on_eos (BT_TEST_ARGS)
   ck_g_object_final_unref (song);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_song_play_pos_after_initial_seek (BT_TEST_ARGS)
+START_TEST (test_bt_song_play_pos_after_initial_seek)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -574,9 +601,9 @@ test_bt_song_play_pos_after_initial_seek (BT_TEST_ARGS)
   ck_g_object_final_unref (song);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_song_play_again_should_restart (BT_TEST_ARGS)
+START_TEST (test_bt_song_play_again_should_restart)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -598,9 +625,9 @@ test_bt_song_play_again_should_restart (BT_TEST_ARGS)
   ck_g_object_final_unref (song);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_song_play_loop (BT_TEST_ARGS)
+START_TEST (test_bt_song_play_loop)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -624,40 +651,46 @@ test_bt_song_play_loop (BT_TEST_ARGS)
   ck_g_object_final_unref (song);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_song_persistence (BT_TEST_ARGS)
+START_TEST (test_bt_song_persistence)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
   BtSong *song = make_new_song ();
 
   GST_INFO ("-- act --");
-  xmlNodePtr node = bt_persistence_save (BT_PERSISTENCE (song), NULL);
+  xmlNodePtr node = bt_persistence_save (BT_PERSISTENCE (song), NULL, NULL);
 
   GST_INFO ("-- assert --");
-  fail_unless (node != NULL, NULL);
+  ck_assert (node != NULL);
   ck_assert_str_eq ((gchar *) node->name, "buzztrax");
-  fail_unless (node->children != NULL, NULL);
+  ck_assert (node->children != NULL);
 
   GST_INFO ("-- cleanup --");
   ck_g_object_final_unref (song);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_song_tempo_update_set_context (BT_TEST_ARGS)
+START_TEST (test_bt_song_tempo_update_set_context)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
   BtSong *song = bt_song_new (app);
   BtSongInfo *song_info =
       BT_SONG_INFO (check_gobject_get_object_property (song, "song-info"));
-  BtMachine *gen = BT_MACHINE (bt_source_machine_new (song, "gen",
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "gen";
+  
+  BtMachine *gen = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-mono-source", 0L, NULL));
   BtTestMonoSource *e =
       (BtTestMonoSource *) check_gobject_get_object_property (gen, "machine");
-  BtMachine *sink = BT_MACHINE (bt_sink_machine_new (song, "master", NULL));
+
+  cparams.id = "master";
+  BtMachine *sink = BT_MACHINE (bt_sink_machine_new (&cparams, NULL));
   bt_wire_new (song, gen, sink, NULL);
 
   GST_INFO ("-- act --");
@@ -671,6 +704,7 @@ test_bt_song_tempo_update_set_context (BT_TEST_ARGS)
   ck_g_object_final_unref (song);
   BT_TEST_END;
 }
+END_TEST
 
 
 

--- a/tests/lib/core/e-source-machine.c
+++ b/tests/lib/core/e-source-machine.c
@@ -67,8 +67,8 @@ START_TEST (test_bt_source_machine_new)
       bt_source_machine_new (&cparams, "buzztrax-test-mono-source", 0, &err);
 
   GST_INFO ("-- assert --");
-  fail_unless (machine != NULL, NULL);
-  fail_unless (err == NULL, NULL);
+  ck_assert (machine != NULL);
+  ck_assert (err == NULL);
 
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
@@ -90,7 +90,7 @@ START_TEST (test_bt_source_machine_def_patterns)
   GList *list = (GList *) check_gobject_get_ptr_property (machine, "patterns");
 
   GST_INFO ("-- assert --");
-  fail_unless (list != NULL, NULL);
+  ck_assert (list != NULL);
   ck_assert_int_eq (g_list_length (list), 3);   /* break+mute+solo */
 
   GST_INFO ("-- cleanup --");
@@ -116,8 +116,8 @@ START_TEST (test_bt_source_machine_pattern)
       BT_MACHINE (machine));
 
   GST_INFO ("-- assert --");
-  fail_unless (pattern != NULL, NULL);
-  ck_assert_gobject_gulong_eq (pattern, "voices", 0);
+  ck_assert (pattern != NULL);
+  ck_assert_gobject_gulong_eq (pattern, "voices", 0L);
 
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
@@ -165,7 +165,7 @@ START_TEST (test_bt_source_machine_pattern_by_index)
       BT_SOURCE_MACHINE_PATTERN_INDEX_MUTE);
 
   GST_INFO ("-- assert --");
-  fail_unless (pattern != NULL, NULL);
+  ck_assert (pattern != NULL);
 
   GST_INFO ("-- cleanup --");
   g_object_unref (pattern);
@@ -191,7 +191,7 @@ START_TEST (test_bt_source_machine_pattern_by_list)
   GList *node = g_list_last (list);
 
   GST_INFO ("-- assert --");
-  fail_unless (node->data == pattern, NULL);
+  ck_assert (node->data == pattern);
 
   GST_INFO ("-- cleanup --");
   g_list_foreach (list, (GFunc) g_object_unref, NULL);
@@ -223,7 +223,7 @@ START_TEST (test_bt_source_machine_change_voices)
   g_object_set (machine, "voices", 4, NULL);
 
   /* verify */
-  ck_assert_gobject_gulong_eq (pattern, "voices", 4);
+  ck_assert_gobject_gulong_eq (pattern, "voices", 4L);
 
   GST_INFO ("-- cleanup --");
   g_object_unref (pattern);

--- a/tests/lib/core/e-source-machine.c
+++ b/tests/lib/core/e-source-machine.c
@@ -52,16 +52,19 @@ case_teardown (void)
 
 //-- tests
 
-static void
-test_bt_source_machine_new (BT_TEST_ARGS)
+START_TEST (test_bt_source_machine_new)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
 
   GST_INFO ("-- act --");
   GError *err = NULL;
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "gen";
+  
   BtSourceMachine *machine =
-      bt_source_machine_new (song, "gen", "buzztrax-test-mono-source", 0, &err);
+      bt_source_machine_new (&cparams, "buzztrax-test-mono-source", 0, &err);
 
   GST_INFO ("-- assert --");
   fail_unless (machine != NULL, NULL);
@@ -70,14 +73,18 @@ test_bt_source_machine_new (BT_TEST_ARGS)
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_source_machine_def_patterns (BT_TEST_ARGS)
+START_TEST (test_bt_source_machine_def_patterns)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "gen";
+  
   BtSourceMachine *machine =
-      bt_source_machine_new (song, "gen", "buzztrax-test-mono-source", 0, NULL);
+    bt_source_machine_new (&cparams, "buzztrax-test-mono-source", 0, NULL);
 
   GST_INFO ("-- act --");
   GList *list = (GList *) check_gobject_get_ptr_property (machine, "patterns");
@@ -91,14 +98,18 @@ test_bt_source_machine_def_patterns (BT_TEST_ARGS)
   g_list_free (list);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_source_machine_pattern (BT_TEST_ARGS)
+START_TEST (test_bt_source_machine_pattern)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "gen";
+  
   BtSourceMachine *machine =
-      bt_source_machine_new (song, "gen", "buzztrax-test-mono-source", 0, NULL);
+    bt_source_machine_new (&cparams, "buzztrax-test-mono-source", 0, NULL);
 
   GST_INFO ("-- act --");
   BtPattern *pattern = bt_pattern_new (song, "pattern-name", 8L,
@@ -111,14 +122,18 @@ test_bt_source_machine_pattern (BT_TEST_ARGS)
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_source_machine_pattern_by_id (BT_TEST_ARGS)
+START_TEST (test_bt_source_machine_pattern_by_id)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "gen";
+  
   BtSourceMachine *machine =
-      bt_source_machine_new (song, "gen", "buzztrax-test-mono-source", 0, NULL);
+    bt_source_machine_new (&cparams, "buzztrax-test-mono-source", 0, NULL);
 
   GST_INFO ("-- act --");
   BtPattern *pattern = bt_pattern_new (song, "pattern-name", 8L,
@@ -132,14 +147,18 @@ test_bt_source_machine_pattern_by_id (BT_TEST_ARGS)
   g_object_unref (pattern);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_source_machine_pattern_by_index (BT_TEST_ARGS)
+START_TEST (test_bt_source_machine_pattern_by_index)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "gen";
+  
   BtSourceMachine *machine =
-      bt_source_machine_new (song, "gen", "buzztrax-test-mono-source", 0, NULL);
+    bt_source_machine_new (&cparams, "buzztrax-test-mono-source", 0, NULL);
 
   GST_INFO ("-- act --");
   BtCmdPattern *pattern = bt_machine_get_pattern_by_index (BT_MACHINE (machine),
@@ -152,14 +171,18 @@ test_bt_source_machine_pattern_by_index (BT_TEST_ARGS)
   g_object_unref (pattern);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_source_machine_pattern_by_list (BT_TEST_ARGS)
+START_TEST (test_bt_source_machine_pattern_by_list)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "gen";
+  
   BtSourceMachine *machine =
-      bt_source_machine_new (song, "gen", "buzztrax-test-mono-source", 0, NULL);
+    bt_source_machine_new (&cparams, "buzztrax-test-mono-source", 0, NULL);
   BtPattern *pattern = bt_pattern_new (song, "pattern-name", 8L,
       BT_MACHINE (machine));
   GList *list = (GList *) check_gobject_get_ptr_property (machine, "patterns");
@@ -176,19 +199,23 @@ test_bt_source_machine_pattern_by_list (BT_TEST_ARGS)
   g_object_unref (pattern);
   BT_TEST_END;
 }
+END_TEST
 
 /*
 * In this example we show how to create a poly source machine and adding a
 * newly created pattern to it. The we change the number of voices in the machine
 * and check back the voices in the pattern.
 */
-static void
-test_bt_source_machine_change_voices (BT_TEST_ARGS)
+START_TEST (test_bt_source_machine_change_voices)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "gen";
+  
   BtSourceMachine *machine =
-      bt_source_machine_new (song, "gen", "buzztrax-test-poly-source", 1, NULL);
+    bt_source_machine_new (&cparams, "buzztrax-test-poly-source", 0, NULL);
   BtPattern *pattern = bt_pattern_new (song, "pattern-name", 8L,
       BT_MACHINE (machine));
 
@@ -202,14 +229,18 @@ test_bt_source_machine_change_voices (BT_TEST_ARGS)
   g_object_unref (pattern);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_source_machine_ref (BT_TEST_ARGS)
+START_TEST (test_bt_source_machine_ref)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "gen";
+  
   BtSourceMachine *machine =
-      bt_source_machine_new (song, "gen", "buzztrax-test-mono-source", 0, NULL);
+    bt_source_machine_new (&cparams, "buzztrax-test-mono-source", 0, NULL);
   BtSetup *setup = BT_SETUP (check_gobject_get_object_property (song, "setup"));
   gst_object_ref (machine);
 
@@ -224,6 +255,7 @@ test_bt_source_machine_ref (BT_TEST_ARGS)
   g_object_unref (setup);
   BT_TEST_END;
 }
+END_TEST
 
 TCase *
 bt_source_machine_example_case (void)

--- a/tests/lib/core/e-tools.c
+++ b/tests/lib/core/e-tools.c
@@ -44,8 +44,7 @@ case_teardown (void)
 
 //-- tests
 
-static void
-test_bt_tools_element_check0 (BT_TEST_ARGS)
+START_TEST (test_bt_tools_element_check0)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -55,14 +54,14 @@ test_bt_tools_element_check0 (BT_TEST_ARGS)
   GList *missing = bt_gst_check_elements (to_check);
 
   GST_INFO ("-- assert --");
-  fail_unless (missing != NULL, NULL);
+  ck_assert (missing != NULL);
   ck_assert_str_eq (missing->data, "__ploink__");
-  fail_unless (g_list_next (missing) == NULL, NULL);
+  ck_assert (g_list_next (missing) == NULL);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_tools_element_check1 (BT_TEST_ARGS)
+START_TEST (test_bt_tools_element_check1)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -73,14 +72,14 @@ test_bt_tools_element_check1 (BT_TEST_ARGS)
   GList *missing = bt_gst_check_elements (to_check);
 
   GST_INFO ("-- assert --");
-  fail_unless (missing != NULL, NULL);
-  fail_unless (g_list_next (missing) != NULL, NULL);
-  fail_unless (g_list_next (g_list_next (missing)) == NULL, NULL);
+  ck_assert (missing != NULL);
+  ck_assert (g_list_next (missing) != NULL);
+  ck_assert (g_list_next (g_list_next (missing)) == NULL);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_str_parse_enum (BT_TEST_ARGS)
+START_TEST (test_bt_str_parse_enum)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -94,9 +93,9 @@ test_bt_str_parse_enum (BT_TEST_ARGS)
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_str_format_enum (BT_TEST_ARGS)
+START_TEST (test_bt_str_format_enum)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -111,9 +110,9 @@ test_bt_str_format_enum (BT_TEST_ARGS)
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_log_message_error (BT_TEST_ARGS)
+START_TEST (test_bt_log_message_error)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -128,8 +127,8 @@ test_bt_log_message_error (BT_TEST_ARGS)
       __LINE__, msg, &message, &description);
 
   GST_INFO ("-- assert --");
-  fail_unless (res, NULL);
-  fail_unless (description != NULL, NULL);
+  ck_assert (res);
+  ck_assert (description != NULL);
   ck_assert_str_eq (message, "description");
 
   GST_INFO ("-- cleanup --");
@@ -139,9 +138,9 @@ test_bt_log_message_error (BT_TEST_ARGS)
   gst_object_unref (src);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_log_message_warning (BT_TEST_ARGS)
+START_TEST (test_bt_log_message_warning)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -156,8 +155,8 @@ test_bt_log_message_warning (BT_TEST_ARGS)
       __LINE__, msg, &message, &description);
 
   GST_INFO ("-- assert --");
-  fail_unless (res, NULL);
-  fail_unless (description != NULL, NULL);
+  ck_assert (res);
+  ck_assert (description != NULL);
   ck_assert_str_eq (message, "description");
 
   GST_INFO ("-- cleanup --");
@@ -167,6 +166,7 @@ test_bt_log_message_warning (BT_TEST_ARGS)
   gst_object_unref (src);
   BT_TEST_END;
 }
+END_TEST
 
 TCase *
 bt_tools_example_case (void)

--- a/tests/lib/core/e-value-group.c
+++ b/tests/lib/core/e-value-group.c
@@ -61,8 +61,11 @@ case_teardown (void)
 static BtValueGroup *
 get_mono_value_group (void)
 {
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "id";
   machine =
-      BT_MACHINE (bt_source_machine_new (song, "id",
+      BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-mono-source", 0, NULL));
   pattern = bt_pattern_new (song, "pattern-name", 4L, machine);
   return bt_pattern_get_global_group (pattern);
@@ -71,22 +74,21 @@ get_mono_value_group (void)
 
 //-- tests
 
-static void
-test_bt_value_group_default_empty (BT_TEST_ARGS)
+START_TEST (test_bt_value_group_default_empty)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
   BtValueGroup *vg = get_mono_value_group ();
 
   /* act && assert */
-  fail_unless (!G_IS_VALUE (bt_value_group_get_event_data (vg, 0, 0)), NULL);
+  ck_assert (!G_IS_VALUE (bt_value_group_get_event_data (vg, 0, 0)));
 
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_value_group_value (BT_TEST_ARGS)
+START_TEST (test_bt_value_group_value)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -101,9 +103,9 @@ test_bt_value_group_value (BT_TEST_ARGS)
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_value_group_insert_row (BT_TEST_ARGS)
+START_TEST (test_bt_value_group_insert_row)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -122,9 +124,9 @@ test_bt_value_group_insert_row (BT_TEST_ARGS)
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_value_group_delete_row (BT_TEST_ARGS)
+START_TEST (test_bt_value_group_delete_row)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -142,9 +144,9 @@ test_bt_value_group_delete_row (BT_TEST_ARGS)
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_value_group_clear_column (BT_TEST_ARGS)
+START_TEST (test_bt_value_group_clear_column)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -162,9 +164,9 @@ test_bt_value_group_clear_column (BT_TEST_ARGS)
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_value_group_clear_columns (BT_TEST_ARGS)
+START_TEST (test_bt_value_group_clear_columns)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -186,6 +188,7 @@ test_bt_value_group_clear_columns (BT_TEST_ARGS)
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
 static struct _blend_column
 {
@@ -201,8 +204,7 @@ static struct _blend_column
   /* *INDENT-ON* */
 };
 
-static void
-test_bt_value_group_blend_column (BT_TEST_ARGS)
+START_TEST (test_bt_value_group_blend_column)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -223,9 +225,9 @@ test_bt_value_group_blend_column (BT_TEST_ARGS)
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_value_group_flip_column (BT_TEST_ARGS)
+START_TEST (test_bt_value_group_flip_column)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -245,9 +247,9 @@ test_bt_value_group_flip_column (BT_TEST_ARGS)
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_value_group_randomize_column (BT_TEST_ARGS)
+START_TEST (test_bt_value_group_randomize_column)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -259,15 +261,15 @@ test_bt_value_group_randomize_column (BT_TEST_ARGS)
   GST_INFO ("-- assert --");
   guint i;
   for (i = 0; i < 4; i++) {
-    fail_unless (G_IS_VALUE (bt_value_group_get_event_data (vg, 0, _i)), NULL);
+    ck_assert (G_IS_VALUE (bt_value_group_get_event_data (vg, 0, _i)));
   }
 
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_value_group_range_randomize_column (BT_TEST_ARGS)
+START_TEST (test_bt_value_group_range_randomize_column)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -285,7 +287,7 @@ test_bt_value_group_range_randomize_column (BT_TEST_ARGS)
   for (i = 0; i < 4; i++) {
     GST_DEBUG ("value[%d]", i);
     str = bt_value_group_get_event (vg, i, 0);
-    fail_unless (str != NULL, NULL);
+    ck_assert (str != NULL);
     v = atoi (str);
     ck_assert_int_ge (v, 5);
     ck_assert_int_le (v, 50);
@@ -295,9 +297,9 @@ test_bt_value_group_range_randomize_column (BT_TEST_ARGS)
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_value_group_transpose_fine_up_column (BT_TEST_ARGS)
+START_TEST (test_bt_value_group_transpose_fine_up_column)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -317,9 +319,9 @@ test_bt_value_group_transpose_fine_up_column (BT_TEST_ARGS)
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_value_group_transpose_fine_down_column (BT_TEST_ARGS)
+START_TEST (test_bt_value_group_transpose_fine_down_column)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -339,9 +341,9 @@ test_bt_value_group_transpose_fine_down_column (BT_TEST_ARGS)
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_value_group_copy (BT_TEST_ARGS)
+START_TEST (test_bt_value_group_copy)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -358,6 +360,7 @@ test_bt_value_group_copy (BT_TEST_ARGS)
   g_object_unref (vg2);
   BT_TEST_END;
 }
+END_TEST
 
 TCase *
 bt_value_group_example_case (void)

--- a/tests/lib/core/e-wave-table.c
+++ b/tests/lib/core/e-wave-table.c
@@ -57,8 +57,7 @@ case_teardown (void)
 
 //-- tests
 
-static void
-test_bt_wave_table_default_empty (BT_TEST_ARGS)
+START_TEST (test_bt_wave_table_default_empty)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -69,15 +68,15 @@ test_bt_wave_table_default_empty (BT_TEST_ARGS)
   GList *list = (GList *) check_gobject_get_ptr_property (wave_table, "waves");
 
   GST_INFO ("-- assert --");
-  fail_unless (list == NULL, NULL);
+  ck_assert (list == NULL);
 
   GST_INFO ("-- cleanup --");
   g_object_unref (wave_table);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_wave_table_add_wave (BT_TEST_ARGS)
+START_TEST (test_bt_wave_table_add_wave)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -90,7 +89,7 @@ test_bt_wave_table_add_wave (BT_TEST_ARGS)
 
   GST_INFO ("-- assert --");
   GList *list = (GList *) check_gobject_get_ptr_property (wave_table, "waves");
-  fail_unless (list != NULL, NULL);
+  ck_assert (list != NULL);
   ck_assert_int_eq (g_list_length (list), 1);
 
   GST_INFO ("-- cleanup --");
@@ -99,9 +98,9 @@ test_bt_wave_table_add_wave (BT_TEST_ARGS)
   g_object_unref (wave_table);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_wave_table_rem_wave (BT_TEST_ARGS)
+START_TEST (test_bt_wave_table_rem_wave)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -115,16 +114,16 @@ test_bt_wave_table_rem_wave (BT_TEST_ARGS)
 
   GST_INFO ("-- assert --");
   GList *list = (GList *) check_gobject_get_ptr_property (wave_table, "waves");
-  fail_unless (list == NULL, NULL);
+  ck_assert (list == NULL);
 
   GST_INFO ("-- cleanup --");
   g_object_unref (wave);
   g_object_unref (wave_table);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_wave_table_get_wave_by_ix (BT_TEST_ARGS)
+START_TEST (test_bt_wave_table_get_wave_by_ix)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -137,7 +136,7 @@ test_bt_wave_table_get_wave_by_ix (BT_TEST_ARGS)
   BtWave *wave_by_ix = bt_wavetable_get_wave_by_index (wave_table, 1);
 
   GST_INFO ("-- assert --");
-  fail_unless (wave == wave_by_ix, NULL);
+  ck_assert (wave == wave_by_ix);
 
   GST_INFO ("-- cleanup --");
   g_object_unref (wave);
@@ -145,9 +144,9 @@ test_bt_wave_table_get_wave_by_ix (BT_TEST_ARGS)
   g_object_unref (wave_table);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_wave_table_replace_wave (BT_TEST_ARGS)
+START_TEST (test_bt_wave_table_replace_wave)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -162,7 +161,7 @@ test_bt_wave_table_replace_wave (BT_TEST_ARGS)
   BtWave *wave_by_ix = bt_wavetable_get_wave_by_index (wave_table, 1);
 
   GST_INFO ("-- assert --");
-  fail_unless (wave2 == wave_by_ix, NULL);
+  ck_assert (wave2 == wave_by_ix);
 
   GST_INFO ("-- cleanup --");
   g_object_unref (wave1);
@@ -171,9 +170,9 @@ test_bt_wave_table_replace_wave (BT_TEST_ARGS)
   g_object_unref (wave_table);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_wave_table_get_callbacks (BT_TEST_ARGS)
+START_TEST (test_bt_wave_table_get_callbacks)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -186,18 +185,18 @@ test_bt_wave_table_get_callbacks (BT_TEST_ARGS)
   gpointer *cb = (gpointer *) bt_wavetable_get_callbacks (wave_table);
 
   GST_INFO ("-- assert --");
-  fail_unless (cb != NULL, NULL);
-  fail_unless (cb[0] != NULL, NULL);
-  fail_unless (cb[1] != NULL, NULL);
+  ck_assert (cb != NULL);
+  ck_assert (cb[0] != NULL);
+  ck_assert (cb[1] != NULL);
 
   GST_INFO ("-- cleanup --");
   g_object_unref (wave);
   g_object_unref (wave_table);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_wave_table_callbacks_get_wave (BT_TEST_ARGS)
+START_TEST (test_bt_wave_table_callbacks_get_wave)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -213,7 +212,7 @@ test_bt_wave_table_callbacks_get_wave (BT_TEST_ARGS)
   GstStructure *s = get_wave_buffer (cb[0], 1, 0);
 
   GST_INFO ("-- assert --");
-  fail_unless (s != NULL, NULL);
+  ck_assert (s != NULL);
 
   GST_INFO ("-- cleanup --");
   gst_structure_free (s);
@@ -221,6 +220,7 @@ test_bt_wave_table_callbacks_get_wave (BT_TEST_ARGS)
   g_object_unref (wave_table);
   BT_TEST_END;
 }
+END_TEST
 
 TCase *
 bt_wave_table_example_case (void)

--- a/tests/lib/core/e-wave.c
+++ b/tests/lib/core/e-wave.c
@@ -57,8 +57,7 @@ case_teardown (void)
 
 //-- tests
 
-static void
-test_bt_wave_default_levels (BT_TEST_ARGS)
+START_TEST (test_bt_wave_default_levels)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -69,13 +68,14 @@ test_bt_wave_default_levels (BT_TEST_ARGS)
   GList *list = (GList *) check_gobject_get_ptr_property (wave, "wavelevels");
 
   GST_INFO ("-- assert --");
-  fail_unless (list != NULL, NULL);
+  ck_assert (list != NULL);
   ck_assert_int_eq (g_list_length (list), 1);
 
   GST_INFO ("-- cleanup --");
   g_object_unref (wave);
   BT_TEST_END;
 }
+END_TEST
 
 TCase *
 bt_wave_example_case (void)

--- a/tests/lib/core/e-wire.c
+++ b/tests/lib/core/e-wire.c
@@ -35,7 +35,11 @@ test_setup (void)
 {
   app = bt_test_application_new ();
   song = bt_song_new (app);
-  bt_sink_machine_new (song, "master", NULL);
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "master";
+  bt_sink_machine_new (&cparams
+                       , NULL);
 }
 
 static void
@@ -53,15 +57,18 @@ case_teardown (void)
 
 //-- tests
 
-static void
-test_bt_wire_can_link (BT_TEST_ARGS)
+START_TEST (test_bt_wire_can_link)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "gen";
   BtMachine *gen =
-      BT_MACHINE (bt_source_machine_new (song, "gen", "audiotestsrc", 0L,
+      BT_MACHINE (bt_source_machine_new (&cparams, "audiotestsrc", 0L,
           NULL));
-  BtMachine *sink = BT_MACHINE (bt_sink_machine_new (song, "master", NULL));
+  cparams.id = "master";
+  BtMachine *sink = BT_MACHINE (bt_sink_machine_new (&cparams, NULL));
 
   /* act & assert */
   fail_unless (bt_wire_can_link (gen, sink));
@@ -69,38 +76,46 @@ test_bt_wire_can_link (BT_TEST_ARGS)
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_wire_new (BT_TEST_ARGS)
+START_TEST (test_bt_wire_new)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "gen";
   BtMachine *gen =
-      BT_MACHINE (bt_source_machine_new (song, "gen", "audiotestsrc", 0L,
+      BT_MACHINE (bt_source_machine_new (&cparams, "audiotestsrc", 0L,
           NULL));
-  BtMachine *sink = BT_MACHINE (bt_sink_machine_new (song, "master", NULL));
+  cparams.id = "master";
+  BtMachine *sink = BT_MACHINE (bt_sink_machine_new (&cparams, NULL));
 
   GST_INFO ("-- act --");
   GError *err = NULL;
   BtWire *wire = bt_wire_new (song, gen, sink, &err);
 
   GST_INFO ("-- assert --");
-  fail_unless (wire != NULL, NULL);
-  fail_unless (err == NULL, NULL);
+  ck_assert (wire != NULL);
+  ck_assert (err == NULL);
 
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_wire_pretty_name (BT_TEST_ARGS)
+START_TEST (test_bt_wire_pretty_name)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "audiotestsrc";
   BtMachine *src =
-      BT_MACHINE (bt_source_machine_new (song, "audiotestsrc", "audiotestsrc",
-          0L, NULL));
-  BtMachine *proc = BT_MACHINE (bt_processor_machine_new (song, "volume",
+      BT_MACHINE (bt_source_machine_new (&cparams, "audiotestsrc", 0L,
+          NULL));
+  cparams.id = "volume";
+  BtMachine *proc = BT_MACHINE (bt_processor_machine_new (&cparams,
           "volume", 0L, NULL));
   BtWire *wire = bt_wire_new (song, src, proc, NULL);
 
@@ -112,16 +127,20 @@ test_bt_wire_pretty_name (BT_TEST_ARGS)
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_wire_pretty_name_gets_updated (BT_TEST_ARGS)
+START_TEST (test_bt_wire_pretty_name_gets_updated)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "audiotestsrc";
   BtMachine *src =
-      BT_MACHINE (bt_source_machine_new (song, "audiotestsrc", "audiotestsrc",
-          0L, NULL));
-  BtMachine *proc = BT_MACHINE (bt_processor_machine_new (song, "volume",
+      BT_MACHINE (bt_source_machine_new (&cparams, "audiotestsrc", 0L,
+          NULL));
+  cparams.id = "volume";
+  BtMachine *proc = BT_MACHINE (bt_processor_machine_new (&cparams,
           "volume", 0L, NULL));
   BtWire *wire = bt_wire_new (song, src, proc, NULL);
 
@@ -135,31 +154,36 @@ test_bt_wire_pretty_name_gets_updated (BT_TEST_ARGS)
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_wire_persistence (BT_TEST_ARGS)
+START_TEST (test_bt_wire_persistence)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "audiotestsrc";
   BtMachine *src =
-      BT_MACHINE (bt_source_machine_new (song, "audiotestsrc", "audiotestsrc",
-          0L, NULL));
-  BtMachine *proc = BT_MACHINE (bt_processor_machine_new (song, "volume",
+      BT_MACHINE (bt_source_machine_new (&cparams, "audiotestsrc", 0L,
+          NULL));
+  cparams.id = "volume";
+  BtMachine *proc = BT_MACHINE (bt_processor_machine_new (&cparams,
           "volume", 0L, NULL));
   BtWire *wire = bt_wire_new (song, src, proc, NULL);
 
   GST_INFO ("-- act --");
   xmlNodePtr parent = xmlNewNode (NULL, XML_CHAR_PTR ("buzztrax"));
-  xmlNodePtr node = bt_persistence_save (BT_PERSISTENCE (wire), parent);
+  xmlNodePtr node = bt_persistence_save (BT_PERSISTENCE (wire), parent, NULL);
 
   GST_INFO ("-- assert --");
-  fail_unless (node != NULL, NULL);
+  ck_assert (node != NULL);
   ck_assert_str_eq ((gchar *) node->name, "wire");
-  fail_unless (node->children != NULL, NULL);
+  ck_assert (node->children != NULL);
 
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
 
 TCase *

--- a/tests/lib/core/t-childproxy.c
+++ b/tests/lib/core/t-childproxy.c
@@ -52,8 +52,7 @@ case_teardown (void)
 
 //-- tests
 
-static void
-test_bt_child_proxy_get (BT_TEST_ARGS)
+START_TEST (test_bt_child_proxy_get)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -68,9 +67,9 @@ test_bt_child_proxy_get (BT_TEST_ARGS)
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_child_proxy_set (BT_TEST_ARGS)
+START_TEST (test_bt_child_proxy_set)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -84,13 +83,14 @@ test_bt_child_proxy_set (BT_TEST_ARGS)
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_child_proxy_get_property (BT_TEST_ARGS)
+START_TEST (test_bt_child_proxy_get_property)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
-  GValue value = { 0, };
+  GValue value = { 0, }
+END_TEST;
   g_value_init (&value, G_TYPE_ULONG);
   g_value_set_ulong (&value, 0);
 
@@ -105,13 +105,14 @@ test_bt_child_proxy_get_property (BT_TEST_ARGS)
   g_value_unset (&value);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_child_proxy_set_property (BT_TEST_ARGS)
+START_TEST (test_bt_child_proxy_set_property)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
-  GValue value = { 0, };
+  GValue value = { 0, }
+END_TEST;
   g_value_init (&value, G_TYPE_ULONG);
   g_value_set_ulong (&value, 0);
 
@@ -125,6 +126,7 @@ test_bt_child_proxy_set_property (BT_TEST_ARGS)
   g_value_unset (&value);
   BT_TEST_END;
 }
+END_TEST
 
 TCase *
 bt_child_proxy_test_case (void)

--- a/tests/lib/core/t-cmd-pattern.c
+++ b/tests/lib/core/t-cmd-pattern.c
@@ -52,26 +52,29 @@ case_teardown (void)
 
 //-- tests
 
-static void
-test_bt_cmd_pattern_properties (BT_TEST_ARGS)
+START_TEST (test_bt_cmd_pattern_properties)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
-  BtMachine *machine = BT_MACHINE (bt_source_machine_new (song, "gen",
+  BtMachineConstructorParams cparams;
+  cparams.id = "gen";
+  cparams.song = song;
+  
+  BtMachine *machine = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-mono-source", 0L, NULL));
   BtCmdPattern *pattern =
       bt_cmd_pattern_new (song, machine, BT_PATTERN_CMD_MUTE);
 
   /* act & assert */
-  fail_unless (check_gobject_properties ((GObject *) pattern), NULL);
+  ck_assert (check_gobject_properties ((GObject *) pattern));
 
   GST_INFO ("-- cleanup --");
   g_object_unref (pattern);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_cmd_pattern_new_null_machine (BT_TEST_ARGS)
+START_TEST (test_bt_cmd_pattern_new_null_machine)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -82,13 +85,14 @@ test_bt_cmd_pattern_new_null_machine (BT_TEST_ARGS)
   BtCmdPattern *pattern = bt_cmd_pattern_new (song, NULL, BT_PATTERN_CMD_MUTE);
 
   GST_INFO ("-- assert --");
-  fail_unless (check_has_error_trapped (), NULL);
-  fail_unless (pattern != NULL, NULL);
+  ck_assert (check_has_error_trapped ());
+  ck_assert (pattern != NULL);
 
   GST_INFO ("-- cleanup --");
   g_object_unref (pattern);
   BT_TEST_END;
 }
+END_TEST
 
 TCase *
 bt_cmd_pattern_test_case (void)

--- a/tests/lib/core/t-core.c
+++ b/tests/lib/core/t-core.c
@@ -52,8 +52,7 @@ case_teardown (void)
 //-- tests
 
 // test init with wrong arg usage
-static void
-test_bt_core_init_bad_arg_value (BT_TEST_ARGS)
+START_TEST (test_bt_core_init_bad_arg_value)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -67,10 +66,10 @@ test_bt_core_init_bad_arg_value (BT_TEST_ARGS)
   GST_INFO ("-- assert --");
   BT_TEST_END;
 }
+END_TEST
 
 // test init with nonsense args
-static void
-test_bt_core_init_bad_arg (BT_TEST_ARGS)
+START_TEST (test_bt_core_init_bad_arg)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -91,9 +90,9 @@ test_bt_core_init_bad_arg (BT_TEST_ARGS)
   g_option_context_free (ctx);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_core_init_bad_arg_exits (BT_TEST_ARGS)
+START_TEST (test_bt_core_init_bad_arg_exits)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -107,6 +106,7 @@ test_bt_core_init_bad_arg_exits (BT_TEST_ARGS)
   GST_INFO ("-- assert --");
   BT_TEST_END;
 }
+END_TEST
 
 TCase *
 bt_core_test_case (void)

--- a/tests/lib/core/t-machine.c
+++ b/tests/lib/core/t-machine.c
@@ -51,12 +51,15 @@ case_teardown (void)
 
 //-- tests
 
-static void
-test_bt_machine_add_null_pattern (BT_TEST_ARGS)
+START_TEST (test_bt_machine_add_null_pattern)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
-  BtMachine *gen1 = BT_MACHINE (bt_source_machine_new (song, "gen",
+  BtMachineConstructorParams cparams;
+  cparams.id = "gen";
+  cparams.song = song;
+  
+  BtMachine *gen1 = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-mono-source", 0L, NULL));
   check_init_error_trapp ("", "BT_IS_CMD_PATTERN (pattern)");
 
@@ -64,18 +67,22 @@ test_bt_machine_add_null_pattern (BT_TEST_ARGS)
   bt_machine_add_pattern (gen1, NULL);
 
   GST_INFO ("-- assert --");
-  fail_unless (check_has_error_trapped (), NULL);
+  ck_assert (check_has_error_trapped ());
 
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_machine_add_pattern_twice (BT_TEST_ARGS)
+START_TEST (test_bt_machine_add_pattern_twice)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
-  BtMachine *gen1 = BT_MACHINE (bt_source_machine_new (song, "gen",
+  BtMachineConstructorParams cparams;
+  cparams.id = "gen";
+  cparams.song = song;
+  
+  BtMachine *gen1 = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-mono-source", 0L, NULL));
   BtPattern *pattern = bt_pattern_new (song, "pattern-name", 8L, gen1);
 
@@ -91,13 +98,17 @@ test_bt_machine_add_pattern_twice (BT_TEST_ARGS)
   g_list_free (list);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_machine_remove_null_pattern (BT_TEST_ARGS)
+START_TEST (test_bt_machine_remove_null_pattern)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
-  BtMachine *gen1 = BT_MACHINE (bt_source_machine_new (song, "gen",
+  BtMachineConstructorParams cparams;
+  cparams.id = "gen";
+  cparams.song = song;
+  
+  BtMachine *gen1 = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-mono-source", 0L, NULL));
   check_init_error_trapp ("", "BT_IS_CMD_PATTERN (pattern)");
 
@@ -105,23 +116,30 @@ test_bt_machine_remove_null_pattern (BT_TEST_ARGS)
   bt_machine_remove_pattern (gen1, NULL);
 
   GST_INFO ("-- assert --");
-  fail_unless (check_has_error_trapped (), NULL);
+  ck_assert (check_has_error_trapped ());
 
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_machine_state_bypass_on_source (BT_TEST_ARGS)
+START_TEST (test_bt_machine_state_bypass_on_source)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
+  BtMachineConstructorParams cparams;
+  cparams.id = "gen";
+  cparams.song = song;
+  
   BtMachine *src =
-      BT_MACHINE (bt_source_machine_new (song, "gen", "audiotestsrc", 0L,
+      BT_MACHINE (bt_source_machine_new (&cparams, "audiotestsrc", 0L,
           NULL));
+
+  cparams.id = "vol";
   BtMachine *proc =
-      BT_MACHINE (bt_processor_machine_new (song, "vol", "volume", 0L, NULL));
-  BtMachine *sink = BT_MACHINE (bt_sink_machine_new (song, "sink", NULL));
+      BT_MACHINE (bt_processor_machine_new (&cparams, "volume", 0L, NULL));
+  cparams.id = "sink";
+  BtMachine *sink = BT_MACHINE (bt_sink_machine_new (&cparams, NULL));
   bt_wire_new (song, src, proc, NULL);
   bt_wire_new (song, proc, sink, NULL);
 
@@ -136,18 +154,26 @@ test_bt_machine_state_bypass_on_source (BT_TEST_ARGS)
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_machine_state_solo_on_sink (BT_TEST_ARGS)
+START_TEST (test_bt_machine_state_solo_on_sink)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
+  BtMachineConstructorParams cparams;
+  cparams.id = "gen";
+  cparams.song = song;
+  
   BtMachine *src =
-      BT_MACHINE (bt_source_machine_new (song, "gen", "audiotestsrc", 0L,
+      BT_MACHINE (bt_source_machine_new (&cparams, "audiotestsrc", 0L,
           NULL));
+
+  cparams.id = "vol";
   BtMachine *proc =
-      BT_MACHINE (bt_processor_machine_new (song, "vol", "volume", 0L, NULL));
-  BtMachine *sink = BT_MACHINE (bt_sink_machine_new (song, "sink", NULL));
+      BT_MACHINE (bt_processor_machine_new (&cparams, "volume", 0L, NULL));
+
+  cparams.id = "sink";
+  BtMachine *sink = BT_MACHINE (bt_sink_machine_new (&cparams, NULL));
   bt_wire_new (song, src, proc, NULL);
   bt_wire_new (song, proc, sink, NULL);
 
@@ -162,6 +188,7 @@ test_bt_machine_state_solo_on_sink (BT_TEST_ARGS)
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
 TCase *
 bt_machine_test_case (void)

--- a/tests/lib/core/t-parameter-group.c
+++ b/tests/lib/core/t-parameter-group.c
@@ -52,12 +52,15 @@ case_teardown (void)
 
 //-- tests
 
-static void
-test_bt_parameter_group_invalid_param (BT_TEST_ARGS)
+START_TEST (test_bt_parameter_group_invalid_param)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
-  BtMachine *machine = BT_MACHINE (bt_source_machine_new (song, "id",
+  BtMachineConstructorParams cparams;
+  cparams.id = "id";
+  cparams.song = song;
+  
+  BtMachine *machine = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-mono-source", 0, NULL));
   BtParameterGroup *pg = bt_machine_get_global_param_group (machine);
 
@@ -70,13 +73,17 @@ test_bt_parameter_group_invalid_param (BT_TEST_ARGS)
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_parameter_group_no_trigger_param (BT_TEST_ARGS)
+START_TEST (test_bt_parameter_group_no_trigger_param)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
-  BtMachine *machine = BT_MACHINE (bt_source_machine_new (song, "id",
+  BtMachineConstructorParams cparams;
+  cparams.id = "id";
+  cparams.song = song;
+  
+  BtMachine *machine = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-no-arg-mono-source", 0, NULL));
   BtParameterGroup *pg = bt_machine_get_global_param_group (machine);
 
@@ -89,13 +96,17 @@ test_bt_parameter_group_no_trigger_param (BT_TEST_ARGS)
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_parameter_group_no_wave_param (BT_TEST_ARGS)
+START_TEST (test_bt_parameter_group_no_wave_param)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
-  BtMachine *machine = BT_MACHINE (bt_source_machine_new (song, "id",
+  BtMachineConstructorParams cparams;
+  cparams.id = "id";
+  cparams.song = song;
+  
+  BtMachine *machine = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-poly-source", 0, NULL));
   BtParameterGroup *pg = bt_machine_get_global_param_group (machine);
 
@@ -108,13 +119,17 @@ test_bt_parameter_group_no_wave_param (BT_TEST_ARGS)
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_parameter_group_set_default_for_prefs (BT_TEST_ARGS)
+START_TEST (test_bt_parameter_group_set_default_for_prefs)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
-  BtMachine *machine = BT_MACHINE (bt_source_machine_new (song, "id",
+  BtMachineConstructorParams cparams;
+  cparams.id = "id";
+  cparams.song = song;
+  
+  BtMachine *machine = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-mono-source", 0, NULL));
   BtParameterGroup *pg = bt_machine_get_prefs_param_group (machine);
 
@@ -128,6 +143,7 @@ test_bt_parameter_group_set_default_for_prefs (BT_TEST_ARGS)
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
 TCase *
 bt_parameter_group_test_case (void)

--- a/tests/lib/core/t-pattern.c
+++ b/tests/lib/core/t-pattern.c
@@ -52,25 +52,28 @@ case_teardown (void)
 
 //-- tests
 
-static void
-test_bt_pattern_properties (BT_TEST_ARGS)
+START_TEST (test_bt_pattern_properties)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
-  BtMachine *machine = BT_MACHINE (bt_source_machine_new (song, "gen",
+  BtMachineConstructorParams cparams;
+  cparams.id = "gen";
+  cparams.song = song;
+  
+  BtMachine *machine = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-mono-source", 0L, NULL));
   BtPattern *pattern = bt_pattern_new (song, "pattern-name", 8L, machine);
 
   /* act & assert */
-  fail_unless (check_gobject_properties ((GObject *) pattern), NULL);
+  ck_assert (check_gobject_properties ((GObject *) pattern));
 
   GST_INFO ("-- cleanup --");
   g_object_unref (pattern);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_pattern_new_null_machine (BT_TEST_ARGS)
+START_TEST (test_bt_pattern_new_null_machine)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -80,20 +83,24 @@ test_bt_pattern_new_null_machine (BT_TEST_ARGS)
   BtPattern *pattern = bt_pattern_new (song, "pattern-name", 1L, NULL);
 
   GST_INFO ("-- assert --");
-  fail_unless (check_has_error_trapped (), NULL);
-  fail_unless (pattern != NULL, NULL);
+  ck_assert (check_has_error_trapped ());
+  ck_assert (pattern != NULL);
 
   GST_INFO ("-- cleanup --");
   g_object_unref (pattern);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_pattern_new_null_name (BT_TEST_ARGS)
+START_TEST (test_bt_pattern_new_null_name)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
-  BtMachine *machine = BT_MACHINE (bt_source_machine_new (song, "id",
+  BtMachineConstructorParams cparams;
+  cparams.id = "id";
+  cparams.song = song;
+  
+  BtMachine *machine = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-mono-source", 0, NULL));
   check_init_error_trapp ("bt_cmd_pattern_", "BT_IS_STRING (self->priv->name)");
 
@@ -101,37 +108,45 @@ test_bt_pattern_new_null_name (BT_TEST_ARGS)
   BtPattern *pattern = bt_pattern_new (song, NULL, 1L, machine);
 
   GST_INFO ("-- assert --");
-  fail_unless (check_has_error_trapped (), NULL);
-  fail_unless (pattern != NULL, NULL);
+  ck_assert (check_has_error_trapped ());
+  ck_assert (pattern != NULL);
 
   GST_INFO ("-- cleanup --");
   g_object_unref (pattern);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_pattern_mono_get_voice_vg (BT_TEST_ARGS)
+START_TEST (test_bt_pattern_mono_get_voice_vg)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
-  BtMachine *machine = BT_MACHINE (bt_source_machine_new (song, "id",
+  BtMachineConstructorParams cparams;
+  cparams.id = "id";
+  cparams.song = song;
+  
+  BtMachine *machine = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-mono-source", 0, NULL));
   BtPattern *pattern = bt_pattern_new (song, "pattern-name", 1L, machine);
 
   /* act && assert */
-  fail_unless (bt_pattern_get_voice_group (pattern, 1) == NULL, NULL);
+  ck_assert (bt_pattern_get_voice_group (pattern, 1) == NULL);
 
   GST_INFO ("-- cleanup --");
   g_object_unref (pattern);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_pattern_get_group_by_null_paramgroup (BT_TEST_ARGS)
+START_TEST (test_bt_pattern_get_group_by_null_paramgroup)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
-  BtMachine *machine = BT_MACHINE (bt_source_machine_new (song, "id",
+  BtMachineConstructorParams cparams;
+  cparams.id = "id";
+  cparams.song = song;
+  
+  BtMachine *machine = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-mono-source", 0, NULL));
   BtPattern *pattern = bt_pattern_new (song, "pattern-name", 1L, machine);
 
@@ -143,6 +158,7 @@ test_bt_pattern_get_group_by_null_paramgroup (BT_TEST_ARGS)
   g_object_unref (pattern);
   BT_TEST_END;
 }
+END_TEST
 
 TCase *
 bt_pattern_test_case (void)

--- a/tests/lib/core/t-pattern.c
+++ b/tests/lib/core/t-pattern.c
@@ -151,8 +151,7 @@ START_TEST (test_bt_pattern_get_group_by_null_paramgroup)
   BtPattern *pattern = bt_pattern_new (song, "pattern-name", 1L, machine);
 
   /* act && assert */
-  fail_unless (bt_pattern_get_group_by_parameter_group (pattern, NULL) == NULL,
-      NULL);
+  ck_assert (bt_pattern_get_group_by_parameter_group (pattern, NULL) == NULL);
 
   GST_INFO ("-- cleanup --");
   g_object_unref (pattern);

--- a/tests/lib/core/t-processor-machine.c
+++ b/tests/lib/core/t-processor-machine.c
@@ -53,46 +53,54 @@ case_teardown (void)
 //-- tests
 
 /* create a machine with not exising plugin name */
-static void
-test_bt_processor_machine_wrong_name (BT_TEST_ARGS)
+START_TEST (test_bt_processor_machine_wrong_name)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
 
   GST_INFO ("-- act --");
   GError *err = NULL;
+  BtMachineConstructorParams cparams;
+  cparams.id = "id";
+  cparams.song = song;
+  
   BtProcessorMachine *machine =
-      bt_processor_machine_new (song, "id", "nonsense", 1, &err);
+      bt_processor_machine_new (&cparams, "nonsense", 1, &err);
 
   GST_INFO ("-- assert --");
-  fail_unless (machine != NULL, NULL);
-  fail_unless (err != NULL, NULL);
+  ck_assert (machine != NULL);
+  ck_assert (err != NULL);
 
   GST_INFO ("-- cleanup --");
   g_error_free (err);
   BT_TEST_END;
 }
+END_TEST
 
 /* create a machine which is a sink machine and not a processor machine */
-static void
-test_bt_processor_machine_wrong_type (BT_TEST_ARGS)
+START_TEST (test_bt_processor_machine_wrong_type)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
 
   /*act */
   GError *err = NULL;
-  BtProcessorMachine *machine =
-      bt_processor_machine_new (song, "id", "autoaudiosink", 1, &err);
+  BtMachineConstructorParams cparams;
+  cparams.id = "id";
+  cparams.song = song;
+  
+  BtMachine *machine = BT_MACHINE (bt_source_machine_new (&cparams,
+      "autoaudiosink", 1, &err));
 
   GST_INFO ("-- assert --");
-  fail_unless (machine != NULL, NULL);
-  fail_unless (err != NULL, NULL);
+  ck_assert (machine != NULL);
+  ck_assert (err != NULL);
 
   GST_INFO ("-- cleanup --");
   g_error_free (err);
   BT_TEST_END;
 }
+END_TEST
 
 TCase *
 bt_processor_machine_test_case (void)

--- a/tests/lib/core/t-sequence.c
+++ b/tests/lib/core/t-sequence.c
@@ -53,40 +53,39 @@ case_teardown (void)
 //-- tests
 
 /* apply generic property tests to sequence */
-static void
-test_bt_sequence_properties (BT_TEST_ARGS)
+START_TEST (test_bt_sequence_properties)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
   GObject *sequence = check_gobject_get_object_property (song, "sequence");
 
   /* act & assert */
-  fail_unless (check_gobject_properties (sequence), NULL);
+  ck_assert (check_gobject_properties (sequence));
 
   GST_INFO ("-- cleanup --");
   ck_g_object_logged_unref (sequence);
   BT_TEST_END;
 }
+END_TEST
 
 /* create a new sequence with NULL for song object */
-static void
-test_bt_sequence_new_null_song (BT_TEST_ARGS)
+START_TEST (test_bt_sequence_new_null_song)
 {
   BT_TEST_START;
   GST_INFO ("-- act --");
   BtSequence *sequence = bt_sequence_new (NULL);
 
   GST_INFO ("-- assert --");
-  fail_unless (sequence != NULL, NULL);
+  ck_assert (sequence != NULL);
 
   GST_INFO ("-- cleanup --");
   ck_g_object_logged_unref (sequence);
   BT_TEST_END;
 }
+END_TEST
 
 /* try to add a NULL machine to the sequence */
-static void
-test_bt_sequence_add_track1 (BT_TEST_ARGS)
+START_TEST (test_bt_sequence_add_track1)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -98,20 +97,24 @@ test_bt_sequence_add_track1 (BT_TEST_ARGS)
   bt_sequence_add_track (sequence, NULL, -1);
 
   GST_INFO ("-- assert --");
-  fail_unless (check_has_error_trapped (), NULL);
+  ck_assert (check_has_error_trapped ());
 
   GST_INFO ("-- cleanup --");
   ck_g_object_logged_unref (sequence);
   BT_TEST_END;
 }
+END_TEST
 
 /* try to add a new machine for the sequence with NULL for the sequence parameter */
-static void
-test_bt_sequence_add_track2 (BT_TEST_ARGS)
+START_TEST (test_bt_sequence_add_track2)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
-  BtMachine *machine = BT_MACHINE (bt_source_machine_new (song, "gen",
+  BtMachineConstructorParams cparams;
+  cparams.id = "gen";
+  cparams.song = song;
+  
+  BtMachine *machine = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-mono-source", 0L, NULL));
   check_init_error_trapp ("", "BT_IS_SEQUENCE (self)");
 
@@ -119,15 +122,15 @@ test_bt_sequence_add_track2 (BT_TEST_ARGS)
   bt_sequence_add_track (NULL, machine, -1);
 
   GST_INFO ("-- assert --");
-  fail_unless (check_has_error_trapped (), NULL);
+  ck_assert (check_has_error_trapped ());
 
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
 /* try to remove a NULL machine from the sequence */
-static void
-test_bt_sequence_rem_track1 (BT_TEST_ARGS)
+START_TEST (test_bt_sequence_rem_track1)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -139,22 +142,26 @@ test_bt_sequence_rem_track1 (BT_TEST_ARGS)
   bt_sequence_remove_track_by_machine (sequence, NULL);
 
   GST_INFO ("-- assert --");
-  fail_unless (check_has_error_trapped (), NULL);
+  ck_assert (check_has_error_trapped ());
 
   GST_INFO ("-- cleanup --");
   ck_g_object_logged_unref (sequence);
   BT_TEST_END;
 }
+END_TEST
 
 /* try to remove a machine from the sequence that has never added */
-static void
-test_bt_sequence_rem_track2 (BT_TEST_ARGS)
+START_TEST (test_bt_sequence_rem_track2)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
   BtSequence *sequence =
       (BtSequence *) check_gobject_get_object_property (song, "sequence");
-  BtMachine *machine = BT_MACHINE (bt_source_machine_new (song, "gen",
+  BtMachineConstructorParams cparams;
+  cparams.id = "gen";
+  cparams.song = song;
+  
+  BtMachine *machine = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-mono-source", 0L, NULL));
 
   GST_INFO ("-- act --");
@@ -167,10 +174,10 @@ test_bt_sequence_rem_track2 (BT_TEST_ARGS)
   ck_g_object_logged_unref (sequence);
   BT_TEST_END;
 }
+END_TEST
 
 /* try to add a label to the sequence beyond the sequence length */
-static void
-test_bt_sequence_length1 (BT_TEST_ARGS)
+START_TEST (test_bt_sequence_length1)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -183,21 +190,26 @@ test_bt_sequence_length1 (BT_TEST_ARGS)
   bt_sequence_set_label (sequence, 5, "test");
 
   GST_INFO ("-- assert --");
-  fail_unless (check_has_error_trapped (), NULL);
+  ck_assert (check_has_error_trapped ());
 
   GST_INFO ("-- cleanup --");
   ck_g_object_logged_unref (sequence);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_sequence_pattern1 (BT_TEST_ARGS)
+START_TEST (test_bt_sequence_pattern1)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
   BtSequence *sequence =
       (BtSequence *) check_gobject_get_object_property (song, "sequence");
-  BtMachine *machine = BT_MACHINE (bt_source_machine_new (song, "gen",
+  
+  BtMachineConstructorParams cparams;
+  cparams.id = "gen";
+  cparams.song = song;
+  
+  BtMachine *machine = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-mono-source", 0L, NULL));
   BtPattern *pattern = bt_pattern_new (song, "pattern-name", 8L, machine);
   g_object_set (sequence, "length", 4L, NULL);
@@ -208,23 +220,29 @@ test_bt_sequence_pattern1 (BT_TEST_ARGS)
   bt_sequence_set_pattern (sequence, 0, 0, (BtCmdPattern *) pattern);
 
   GST_INFO ("-- assert --");
-  fail_unless (check_has_error_trapped (), NULL);
+  ck_assert (check_has_error_trapped ());
 
   GST_INFO ("-- cleanup --");
   ck_g_object_logged_unref (pattern);
   ck_g_object_logged_unref (sequence);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_sequence_pattern2 (BT_TEST_ARGS)
+START_TEST (test_bt_sequence_pattern2)
 {
   BT_TEST_START;
   BtSequence *sequence =
       (BtSequence *) check_gobject_get_object_property (song, "sequence");
-  BtMachine *machine1 = BT_MACHINE (bt_source_machine_new (song, "genm",
+  BtMachineConstructorParams cparams;
+  cparams.id = "genm";
+  cparams.song = song;
+  
+  BtMachine *machine1 = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-mono-source", 0L, NULL));
-  BtMachine *machine2 = BT_MACHINE (bt_source_machine_new (song, "genp",
+
+  cparams.id = "genp";
+  BtMachine *machine2 = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-poly-source", 1L, NULL));
   BtCmdPattern *pattern1 =
       (BtCmdPattern *) bt_pattern_new (song, "pattern-name", 8L, machine1);
@@ -238,7 +256,7 @@ test_bt_sequence_pattern2 (BT_TEST_ARGS)
   bt_sequence_set_pattern (sequence, 0, 1, pattern1);
 
   GST_INFO ("-- assert --");
-  fail_unless (check_has_error_trapped (), NULL);
+  ck_assert (check_has_error_trapped ());
 
   GST_INFO ("-- cleanup --");
   ck_assert_gobject_ref_ct (machine1, 2);       // song, sequence
@@ -247,6 +265,7 @@ test_bt_sequence_pattern2 (BT_TEST_ARGS)
   ck_g_object_remaining_unref (sequence, 1);    // song
   BT_TEST_END;
 }
+END_TEST
 
 TCase *
 bt_sequence_test_case (void)

--- a/tests/lib/core/t-setup.c
+++ b/tests/lib/core/t-setup.c
@@ -52,79 +52,90 @@ case_teardown (void)
 
 //-- tests
 
-static void
-test_bt_setup_properties (BT_TEST_ARGS)
+START_TEST (test_bt_setup_properties)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
   GObject *setup = check_gobject_get_object_property (song, "setup");
 
   /* act & assert */
-  fail_unless (check_gobject_properties (setup), NULL);
+  ck_assert (check_gobject_properties (setup));
 
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
 /* create a new setup with NULL for song object */
-static void
-test_bt_setup_new_null_song (BT_TEST_ARGS)
+START_TEST (test_bt_setup_new_null_song)
 {
   BT_TEST_START;
   GST_INFO ("-- act --");
   BtSetup *setup = bt_setup_new (NULL);
 
   GST_INFO ("-- assert --");
-  fail_unless (setup != NULL, NULL);
+  ck_assert (setup != NULL);
 
   GST_INFO ("-- cleanup --");
   g_object_unref (setup);
   BT_TEST_END;
 }
+END_TEST
 
 /* add the same machine twice to the setup */
-static void
-test_bt_setup_add_machine_twice (BT_TEST_ARGS)
+START_TEST (test_bt_setup_add_machine_twice)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
   BtSetup *setup =
       (BtSetup *) check_gobject_get_object_property (song, "setup");
-  BtMachine *machine = BT_MACHINE (bt_source_machine_new (song, "gen",
+  
+  BtMachineConstructorParams cparams;
+  cparams.id = "gen";
+  cparams.song = song;
+  
+  BtMachine *machine = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-mono-source", 0, NULL));
 
   /* act & assert */
-  fail_if (bt_setup_add_machine (setup, machine), NULL);
+  ck_assert (!bt_setup_add_machine (setup, machine));
 
   GST_INFO ("-- cleanup --");
   g_object_unref (setup);
   BT_TEST_END;
 }
+END_TEST
 
 /* add the same wire twice */
-static void
-test_bt_setup_add_wire_twice (BT_TEST_ARGS)
+START_TEST (test_bt_setup_add_wire_twice)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
   BtSetup *setup =
       (BtSetup *) check_gobject_get_object_property (song, "setup");
-  BtMachine *source = BT_MACHINE (bt_source_machine_new (song, "gen",
+  
+  BtMachineConstructorParams cparams;
+  cparams.id = "gen";
+  cparams.song = song;
+  
+  BtMachine *source = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-mono-source", 0L, NULL));
-  BtMachine *sink = BT_MACHINE (bt_sink_machine_new (song, "sink", NULL));
+
+  cparams.id = "sink";
+  BtMachine *sink = BT_MACHINE (bt_sink_machine_new (&cparams, NULL));
   BtWire *wire = bt_wire_new (song, source, sink, NULL);
 
   /* act & assert */
-  fail_if (bt_setup_add_wire (setup, wire), NULL);
+  ck_assert (!bt_setup_add_wire (setup, wire));
 
   GST_INFO ("-- cleanup --");
   g_object_unref (setup);
   BT_TEST_END;
 }
+END_TEST
 
 /* call bt_setup_add_machine with NULL object for self */
-static void
-test_bt_setup_obj4 (BT_TEST_ARGS)
+START_TEST (test_bt_setup_obj4)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -134,15 +145,15 @@ test_bt_setup_obj4 (BT_TEST_ARGS)
   bt_setup_add_machine (NULL, NULL);
 
   GST_INFO ("-- assert --");
-  fail_unless (check_has_error_trapped (), NULL);
+  ck_assert (check_has_error_trapped ());
 
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
 /* call bt_setup_add_machine with NULL object for machine */
-static void
-test_bt_setup_obj5 (BT_TEST_ARGS)
+START_TEST (test_bt_setup_obj5)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -154,16 +165,16 @@ test_bt_setup_obj5 (BT_TEST_ARGS)
   bt_setup_add_machine (setup, NULL);
 
   GST_INFO ("-- assert --");
-  fail_unless (check_has_error_trapped (), NULL);
+  ck_assert (check_has_error_trapped ());
 
   GST_INFO ("-- cleanup --");
   g_object_unref (setup);
   BT_TEST_END;
 }
+END_TEST
 
 /* call bt_setup_add_wire with NULL object for self */
-static void
-test_bt_setup_obj6 (BT_TEST_ARGS)
+START_TEST (test_bt_setup_obj6)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -173,15 +184,15 @@ test_bt_setup_obj6 (BT_TEST_ARGS)
   bt_setup_add_wire (NULL, NULL);
 
   GST_INFO ("-- assert --");
-  fail_unless (check_has_error_trapped (), NULL);
+  ck_assert (check_has_error_trapped ());
 
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
 /* call bt_setup_add_wire with NULL object for wire */
-static void
-test_bt_setup_obj7 (BT_TEST_ARGS)
+START_TEST (test_bt_setup_obj7)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -193,16 +204,16 @@ test_bt_setup_obj7 (BT_TEST_ARGS)
   bt_setup_add_wire (setup, NULL);
 
   GST_INFO ("-- assert --");
-  fail_unless (check_has_error_trapped (), NULL);
+  ck_assert (check_has_error_trapped ());
 
   GST_INFO ("-- cleanup --");
   g_object_unref (setup);
   BT_TEST_END;
 }
+END_TEST
 
 /* call bt_setup_get_machine_by_id with NULL object for self */
-static void
-test_bt_setup_obj8 (BT_TEST_ARGS)
+START_TEST (test_bt_setup_obj8)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -212,15 +223,15 @@ test_bt_setup_obj8 (BT_TEST_ARGS)
   bt_setup_get_machine_by_id (NULL, NULL);
 
   GST_INFO ("-- assert --");
-  fail_unless (check_has_error_trapped (), NULL);
+  ck_assert (check_has_error_trapped ());
 
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
 /* call bt_setup_get_machine_by_id with NULL object for id */
-static void
-test_bt_setup_obj9 (BT_TEST_ARGS)
+START_TEST (test_bt_setup_obj9)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -232,18 +243,18 @@ test_bt_setup_obj9 (BT_TEST_ARGS)
   bt_setup_get_machine_by_id (setup, NULL);
 
   GST_INFO ("-- assert --");
-  fail_unless (check_has_error_trapped (), NULL);
+  ck_assert (check_has_error_trapped ());
 
   GST_INFO ("-- cleanup --");
   g_object_unref (setup);
   BT_TEST_END;
 }
+END_TEST
 
 /*
 * call bt_setup_get_wire_by_src_machine with NULL for setup parameter
 */
-static void
-test_bt_setup_get_wire_by_src_machine1 (BT_TEST_ARGS)
+START_TEST (test_bt_setup_get_wire_by_src_machine1)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -254,15 +265,15 @@ test_bt_setup_get_wire_by_src_machine1 (BT_TEST_ARGS)
   bt_setup_get_wire_by_src_machine (NULL, NULL);
 
   GST_INFO ("-- assert --");
-  fail_unless (check_has_error_trapped (), NULL);
+  ck_assert (check_has_error_trapped ());
 
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
 /* call bt_setup_get_wire_by_src_machine with NULL for machine parameter */
-static void
-test_bt_setup_get_wire_by_src_machine2 (BT_TEST_ARGS)
+START_TEST (test_bt_setup_get_wire_by_src_machine2)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -275,23 +286,27 @@ test_bt_setup_get_wire_by_src_machine2 (BT_TEST_ARGS)
   bt_setup_get_wire_by_src_machine (setup, NULL);
 
   GST_INFO ("-- assert --");
-  fail_unless (check_has_error_trapped (), NULL);
+  ck_assert (check_has_error_trapped ());
 
   GST_INFO ("-- cleanup --");
   g_object_unref (setup);
   BT_TEST_END;
 }
+END_TEST
 
 /* get wires by source machine with NULL for setup */
-static void
-test_bt_setup_get_wires_by_src_machine1 (BT_TEST_ARGS)
+START_TEST (test_bt_setup_get_wires_by_src_machine1)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
   BtSetup *setup =
       (BtSetup *) check_gobject_get_object_property (song, "setup");
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "src";
+  
   BtSourceMachine *src_machine =
-      bt_source_machine_new (song, "src", "buzztrax-test-mono-source", 0L,
+      bt_source_machine_new (&cparams, "buzztrax-test-mono-source", 0L,
       NULL);
   check_init_error_trapp ("bt_setup_get_wires_by_src_machine",
       "BT_IS_SETUP (self)");
@@ -300,16 +315,16 @@ test_bt_setup_get_wires_by_src_machine1 (BT_TEST_ARGS)
   bt_setup_get_wires_by_src_machine (NULL, BT_MACHINE (src_machine));
 
   GST_INFO ("-- assert --");
-  fail_unless (check_has_error_trapped (), NULL);
+  ck_assert (check_has_error_trapped ());
 
   GST_INFO ("-- cleanup --");
   g_object_unref (setup);
   BT_TEST_END;
 }
+END_TEST
 
 /* get wires by source machine with NULL for machine */
-static void
-test_bt_setup_get_wires_by_src_machine2 (BT_TEST_ARGS)
+START_TEST (test_bt_setup_get_wires_by_src_machine2)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -320,36 +335,41 @@ test_bt_setup_get_wires_by_src_machine2 (BT_TEST_ARGS)
 
   GST_INFO ("-- act --");
   bt_setup_get_wires_by_src_machine (setup, NULL);
-  fail_unless (check_has_error_trapped (), NULL);
+  ck_assert (check_has_error_trapped ());
 
   GST_INFO ("-- cleanup --");
   g_object_unref (setup);
   BT_TEST_END;
 }
+END_TEST
 
 /* get wires by source machine with a not added machine */
-static void
-test_bt_setup_get_wires_by_src_machine3 (BT_TEST_ARGS)
+START_TEST (test_bt_setup_get_wires_by_src_machine3)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
   BtSetup *setup =
       (BtSetup *) check_gobject_get_object_property (song, "setup");
-  BtMachine *machine = BT_MACHINE (bt_source_machine_new (song, "src",
-          "buzztrax-test-mono-source", 0L, NULL));
-  bt_setup_remove_machine (setup, machine);
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "src";
+  
+  BtSourceMachine *machine =
+      bt_source_machine_new (&cparams, "buzztrax-test-mono-source", 0L,
+      NULL);
+  bt_setup_remove_machine (setup, BT_MACHINE (machine));
 
   /* act & assert */
-  fail_if (bt_setup_get_wires_by_src_machine (setup, machine), NULL);
+  ck_assert (!bt_setup_get_wires_by_src_machine (setup, BT_MACHINE (machine)));
 
   GST_INFO ("-- cleanup --");
   g_object_unref (setup);
   BT_TEST_END;
 }
+END_TEST
 
 /* call bt_setup_get_wire_by_dst_machine with NULL for setup parameter */
-static void
-test_bt_setup_get_wire_by_dst_machine1 (BT_TEST_ARGS)
+START_TEST (test_bt_setup_get_wire_by_dst_machine1)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -362,16 +382,16 @@ test_bt_setup_get_wire_by_dst_machine1 (BT_TEST_ARGS)
   bt_setup_get_wire_by_dst_machine (NULL, NULL);
 
   GST_INFO ("-- assert --");
-  fail_unless (check_has_error_trapped (), NULL);
+  ck_assert (check_has_error_trapped ());
 
   GST_INFO ("-- cleanup --");
   g_object_unref (setup);
   BT_TEST_END;
 }
+END_TEST
 
 /* call bt_setup_get_wire_by_dst_machine with NULL for machine parameter */
-static void
-test_bt_setup_get_wire_by_dst_machine2 (BT_TEST_ARGS)
+START_TEST (test_bt_setup_get_wire_by_dst_machine2)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -384,22 +404,27 @@ test_bt_setup_get_wire_by_dst_machine2 (BT_TEST_ARGS)
   bt_setup_get_wire_by_dst_machine (setup, NULL);
 
   GST_INFO ("-- assert --");
-  fail_unless (check_has_error_trapped (), NULL);
+  ck_assert (check_has_error_trapped ());
 
   GST_INFO ("-- cleanup --");
   g_object_unref (setup);
   BT_TEST_END;
 }
+END_TEST
 
 /* get wires by destination machine with NULL for setup */
-static void
-test_bt_setup_get_wires_by_dst_machine1 (BT_TEST_ARGS)
+START_TEST (test_bt_setup_get_wires_by_dst_machine1)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
   BtSetup *setup =
       (BtSetup *) check_gobject_get_object_property (song, "setup");
-  BtMachine *machine = BT_MACHINE (bt_sink_machine_new (song, "dst", NULL));
+  
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "dst";
+  
+  BtMachine *machine = BT_MACHINE (bt_sink_machine_new (&cparams, NULL));
   check_init_error_trapp ("bt_setup_get_wires_by_dst_machine",
       "BT_IS_SETUP (self)");
 
@@ -407,16 +432,16 @@ test_bt_setup_get_wires_by_dst_machine1 (BT_TEST_ARGS)
   bt_setup_get_wires_by_dst_machine (NULL, machine);
 
   GST_INFO ("-- assert --");
-  fail_unless (check_has_error_trapped (), NULL);
+  ck_assert (check_has_error_trapped ());
 
   GST_INFO ("-- cleanup --");
   g_object_unref (setup);
   BT_TEST_END;
 }
+END_TEST
 
 /* get wires by sink machine with NULL for machine */
-static void
-test_bt_setup_get_wires_by_dst_machine2 (BT_TEST_ARGS)
+START_TEST (test_bt_setup_get_wires_by_dst_machine2)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -429,35 +454,40 @@ test_bt_setup_get_wires_by_dst_machine2 (BT_TEST_ARGS)
   bt_setup_get_wires_by_dst_machine (setup, NULL);
 
   GST_INFO ("-- assert --");
-  fail_unless (check_has_error_trapped (), NULL);
+  ck_assert (check_has_error_trapped ());
 
   GST_INFO ("-- cleanup --");
   g_object_unref (setup);
   BT_TEST_END;
 }
+END_TEST
 
 /* get wires by sink machine with a not added machine */
-static void
-test_bt_setup_get_wires_by_dst_machine3 (BT_TEST_ARGS)
+START_TEST (test_bt_setup_get_wires_by_dst_machine3)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
   BtSetup *setup =
       (BtSetup *) check_gobject_get_object_property (song, "setup");
-  BtMachine *machine = BT_MACHINE (bt_sink_machine_new (song, "dst", NULL));
+  
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "dst";
+  
+  BtMachine *machine = BT_MACHINE (bt_sink_machine_new (&cparams, NULL));
   bt_setup_remove_machine (setup, machine);
 
   /* act & assert */
-  fail_if (bt_setup_get_wires_by_dst_machine (setup, machine), NULL);
+  ck_assert (!bt_setup_get_wires_by_dst_machine (setup, machine));
 
   GST_INFO ("-- cleanup --");
   g_object_unref (setup);
   BT_TEST_END;
 }
+END_TEST
 
 /* remove a machine from setup with NULL pointer for setup */
-static void
-test_bt_setup_remove_machine_null_setup (BT_TEST_ARGS)
+START_TEST (test_bt_setup_remove_machine_null_setup)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -467,15 +497,15 @@ test_bt_setup_remove_machine_null_setup (BT_TEST_ARGS)
   bt_setup_remove_machine (NULL, NULL);
 
   GST_INFO ("-- assert --");
-  fail_unless (check_has_error_trapped (), NULL);
+  ck_assert (check_has_error_trapped ());
 
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
 /* remove a wire from setup with NULL pointer for setup */
-static void
-test_bt_setup_remove_wire_null_setup (BT_TEST_ARGS)
+START_TEST (test_bt_setup_remove_wire_null_setup)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -485,15 +515,15 @@ test_bt_setup_remove_wire_null_setup (BT_TEST_ARGS)
   bt_setup_remove_wire (NULL, NULL);
 
   GST_INFO ("-- assert --");
-  fail_unless (check_has_error_trapped (), NULL);
+  ck_assert (check_has_error_trapped ());
 
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
 /* remove a machine from setup with NULL pointer for machine */
-static void
-test_bt_setup_remove_null_machine (BT_TEST_ARGS)
+START_TEST (test_bt_setup_remove_null_machine)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -505,16 +535,16 @@ test_bt_setup_remove_null_machine (BT_TEST_ARGS)
   bt_setup_remove_machine (setup, NULL);
 
   GST_INFO ("-- assert --");
-  fail_unless (check_has_error_trapped (), NULL);
+  ck_assert (check_has_error_trapped ());
 
   GST_INFO ("-- cleanup --");
   g_object_unref (setup);
   BT_TEST_END;
 }
+END_TEST
 
 /* remove a wire from setup with NULL pointer for wire */
-static void
-test_bt_setup_remove_null_wire (BT_TEST_ARGS)
+START_TEST (test_bt_setup_remove_null_wire)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -526,22 +556,25 @@ test_bt_setup_remove_null_wire (BT_TEST_ARGS)
   bt_setup_remove_wire (setup, NULL);
 
   GST_INFO ("-- assert --");
-  fail_unless (check_has_error_trapped (), NULL);
+  ck_assert (check_has_error_trapped ());
 
   GST_INFO ("-- cleanup --");
   g_object_unref (setup);
   BT_TEST_END;
 }
+END_TEST
 
 /* remove a machine from setup with a machine witch is never added */
-static void
-test_bt_setup_remove_machine_twice (BT_TEST_ARGS)
+START_TEST (test_bt_setup_remove_machine_twice)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
   BtSetup *setup =
       (BtSetup *) check_gobject_get_object_property (song, "setup");
-  BtMachine *gen = BT_MACHINE (bt_source_machine_new (song, "src",
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "src";
+  BtMachine *gen = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-mono-source", 0L, NULL));
   gst_object_ref (gen);
   bt_setup_remove_machine (setup, gen);
@@ -551,25 +584,32 @@ test_bt_setup_remove_machine_twice (BT_TEST_ARGS)
   bt_setup_remove_machine (setup, gen);
 
   GST_INFO ("-- assert --");
-  fail_unless (check_has_error_trapped (), NULL);
+  ck_assert (check_has_error_trapped ());
 
   GST_INFO ("-- cleanup --");
   gst_object_unref (gen);
   g_object_unref (setup);
   BT_TEST_END;
 }
+END_TEST
 
 /* remove a wire from setup with a wire which is not added */
-static void
-test_bt_setup_remove_wire_twice (BT_TEST_ARGS)
+START_TEST (test_bt_setup_remove_wire_twice)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
   BtSetup *setup =
       (BtSetup *) check_gobject_get_object_property (song, "setup");
-  BtMachine *gen = BT_MACHINE (bt_source_machine_new (song, "src",
+  
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "src";
+  
+  BtMachine *gen = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-mono-source", 0L, NULL));
-  BtMachine *sink = BT_MACHINE (bt_sink_machine_new (song, "dst", NULL));
+
+  cparams.id = "dst";
+  BtMachine *sink = BT_MACHINE (bt_sink_machine_new (&cparams, NULL));
   BtWire *wire = bt_wire_new (song, gen, sink, NULL);
   gst_object_ref (wire);
   bt_setup_remove_wire (setup, wire);
@@ -579,26 +619,78 @@ test_bt_setup_remove_wire_twice (BT_TEST_ARGS)
   bt_setup_remove_wire (setup, wire);
 
   GST_INFO ("-- assert --");
-  fail_unless (check_has_error_trapped (), NULL);
+  ck_assert (check_has_error_trapped ());
 
   GST_INFO ("-- cleanup --");
   gst_object_unref (wire);
   g_object_unref (setup);
   BT_TEST_END;
 }
+END_TEST
 
-/* add wire(src,dst) and wire(dst,src) to setup. This should fail (cycle). */
-static void
-test_bt_setup_wire_cycle1 (BT_TEST_ARGS)
+/**
+ * Ensure that creating multiple machines with the same name results in the
+ * correct unique name pattern.
+ */
+START_TEST (test_bt_setup_unique_machine_id)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
   BtSetup *setup =
       (BtSetup *) check_gobject_get_object_property (song, "setup");
+
+  GST_INFO ("-- act --");
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "src1";
+  
+  BtMachine *elem1 =
+      BT_MACHINE (bt_processor_machine_new (&cparams, "volume", 0L, NULL));
+  
+  cparams.id = bt_setup_get_unique_machine_id (setup, "src1");
+  BtMachine *elem2 =
+      BT_MACHINE (bt_processor_machine_new (&cparams, "volume", 0L, NULL));
+  g_free (cparams.id);
+  
+  cparams.id = bt_setup_get_unique_machine_id (setup, "src1");
+  BtMachine *elem3 =
+      BT_MACHINE (bt_processor_machine_new (&cparams, "volume", 0L, NULL));
+  g_free (cparams.id);
+
+  GST_INFO ("-- assert --");
+  gchar* id = NULL;
+  
+  g_object_get (G_OBJECT (elem1), "id", &id, NULL);
+  ck_assert_str_eq_and_free (id, "src1");
+  
+  g_object_get (G_OBJECT (elem2), "id", &id, NULL);
+  ck_assert_str_eq_and_free (id, "src1 00");
+
+  g_object_get (G_OBJECT (elem3), "id", &id, NULL);
+  ck_assert_str_eq_and_free (id, "src1 01");
+  
+  GST_INFO ("-- cleanup --");
+  g_object_unref (setup);
+  BT_TEST_END;
+}
+END_TEST
+
+/* add wire(src,dst) and wire(dst,src) to setup. This should fail (cycle). */
+START_TEST (test_bt_setup_wire_cycle1)
+{
+  BT_TEST_START;
+  GST_INFO ("-- arrange --");
+  BtSetup *setup =
+      (BtSetup *) check_gobject_get_object_property (song, "setup");
+  
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "src";
+  
   BtMachine *src =
-      BT_MACHINE (bt_processor_machine_new (song, "src", "volume", 0L, NULL));
+      BT_MACHINE (bt_processor_machine_new (&cparams, "volume", 0L, NULL));
   BtMachine *dst =
-      BT_MACHINE (bt_processor_machine_new (song, "src", "volume", 0L, NULL));
+      BT_MACHINE (bt_processor_machine_new (&cparams, "volume", 0L, NULL));
   bt_wire_new (song, src, dst, NULL);
 
   GST_INFO ("-- act --");
@@ -606,29 +698,37 @@ test_bt_setup_wire_cycle1 (BT_TEST_ARGS)
   BtWire *wire2 = bt_wire_new (song, dst, src, &err);
 
   GST_INFO ("-- assert --");
-  fail_unless (wire2 != NULL, NULL);
-  fail_unless (err != NULL, NULL);
+  ck_assert (wire2 != NULL);
+  ck_assert (err != NULL);
 
   GST_INFO ("-- cleanup --");
   g_object_unref (setup);
   BT_TEST_END;
 }
+END_TEST
 
 // test graph cycles
-static void
-test_bt_setup_wire_cycle2 (BT_TEST_ARGS)
+START_TEST (test_bt_setup_wire_cycle2)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
   BtSetup *setup =
       (BtSetup *) check_gobject_get_object_property (song, "setup");
+  
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "src1";
+  
   BtMachine *elem1 =
-      BT_MACHINE (bt_processor_machine_new (song, "src1", "volume", 0L, NULL));
+      BT_MACHINE (bt_processor_machine_new (&cparams, "volume", 0L, NULL));
+  cparams.id = "src2";
   BtMachine *elem2 =
-      BT_MACHINE (bt_processor_machine_new (song, "src2", "volume", 0L, NULL));
+      BT_MACHINE (bt_processor_machine_new (&cparams, "volume", 0L, NULL));
+  cparams.id = "src3";
   BtMachine *elem3 =
-      BT_MACHINE (bt_processor_machine_new (song, "src3", "volume", 0L, NULL));
-  BtMachine *sink = BT_MACHINE (bt_sink_machine_new (song, "sink", NULL));
+      BT_MACHINE (bt_processor_machine_new (&cparams, "volume", 0L, NULL));
+  cparams.id = "sink";
+  BtMachine *sink = BT_MACHINE (bt_sink_machine_new (&cparams, NULL));
   bt_wire_new (song, elem3, sink, NULL);
   bt_wire_new (song, elem1, elem2, NULL);
   bt_wire_new (song, elem2, elem3, NULL);
@@ -638,13 +738,14 @@ test_bt_setup_wire_cycle2 (BT_TEST_ARGS)
   BtWire *wire3 = bt_wire_new (song, elem3, elem1, &err);
 
   GST_INFO ("-- assert --");
-  fail_unless (wire3 != NULL, NULL);
-  fail_unless (err != NULL, NULL);
+  ck_assert (wire3 != NULL);
+  ck_assert (err != NULL);
 
   GST_INFO ("-- cleanup --");
   g_object_unref (setup);
   BT_TEST_END;
 }
+END_TEST
 
 TCase *
 bt_setup_test_case (void)
@@ -677,6 +778,7 @@ bt_setup_test_case (void)
   tcase_add_test (tc, test_bt_setup_remove_null_wire);
   tcase_add_test (tc, test_bt_setup_remove_machine_twice);
   tcase_add_test (tc, test_bt_setup_remove_wire_twice);
+  tcase_add_test (tc, test_bt_setup_unique_machine_id);
   tcase_add_test (tc, test_bt_setup_wire_cycle1);
   tcase_add_test (tc, test_bt_setup_wire_cycle2);
   tcase_add_checked_fixture (tc, test_setup, test_teardown);

--- a/tests/lib/core/t-sink-bin.c
+++ b/tests/lib/core/t-sink-bin.c
@@ -51,20 +51,20 @@ case_teardown (void)
 
 //-- tests
 
-static void
-test_bt_sink_bin_properties (BT_TEST_ARGS)
+START_TEST (test_bt_sink_bin_properties)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
   GstElement *bin = gst_element_factory_make ("bt-sink-bin", NULL);
 
   /* act & assert */
-  fail_unless (check_gobject_properties ((GObject *) bin), NULL);
+  ck_assert (check_gobject_properties ((GObject *) bin));
 
   GST_INFO ("-- cleanup --");
   mark_point ();
   BT_TEST_END;
 }
+END_TEST
 
 ;
 

--- a/tests/lib/core/t-sink-machine.c
+++ b/tests/lib/core/t-sink-machine.c
@@ -57,10 +57,15 @@ case_teardown (void)
 static void
 make_test_song (void)
 {
-  BtMachine *sink = BT_MACHINE (bt_sink_machine_new (song, "master", NULL));
-  BtMachine *gen =
-      BT_MACHINE (bt_source_machine_new (song, "gen", "audiotestsrc", 0L,
-          NULL));
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "master";
+  
+  BtMachine *sink = BT_MACHINE (bt_sink_machine_new (&cparams, NULL));
+
+  cparams.id = "gen";
+  BtMachine *gen = BT_MACHINE (bt_source_machine_new (&cparams,
+      "audiotestsrc", 0L, NULL));
   bt_wire_new (song, gen, sink, NULL);
   GstElement *element =
       (GstElement *) check_gobject_get_object_property (gen, "machine");
@@ -74,8 +79,7 @@ make_test_song (void)
 //-- tests
 
 // test attribute handling in sink names
-static void
-test_bt_sink_machine_settings_name_with_parameter (BT_TEST_ARGS)
+START_TEST (test_bt_sink_machine_settings_name_with_parameter)
 {
   BT_TEST_START;
 
@@ -85,23 +89,27 @@ test_bt_sink_machine_settings_name_with_parameter (BT_TEST_ARGS)
 
   GST_INFO ("-- act --");
   GError *err = NULL;
-  BtSinkMachine *machine = bt_sink_machine_new (song, "master", &err);
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "master";
+  
+  BtMachine *machine = BT_MACHINE (bt_sink_machine_new (&cparams, NULL));
 
   GST_INFO ("-- assert --");
-  fail_unless (machine != NULL, NULL);
-  fail_unless (err == NULL, NULL);
+  ck_assert (machine != NULL);
+  ck_assert (err == NULL);
 
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
 
 /* Check if we handle a sink setting of "audioconvert ! osssink sync=false".
  * This string should be replaced by the sink machine to "ossink" and the
  * machine should be instantiable.
  */
-static void
-test_bt_sink_machine_settings_name_is_launch_snippet (BT_TEST_ARGS)
+START_TEST (test_bt_sink_machine_settings_name_is_launch_snippet)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -110,20 +118,24 @@ test_bt_sink_machine_settings_name_is_launch_snippet (BT_TEST_ARGS)
 
   GST_INFO ("-- act --");
   GError *err = NULL;
-  BtSinkMachine *machine = bt_sink_machine_new (song, "master", &err);
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "master";
+  
+  BtSinkMachine *machine = bt_sink_machine_new (&cparams, &err);
 
   GST_INFO ("-- assert --");
-  fail_unless (machine != NULL, NULL);
-  fail_unless (err == NULL, NULL);
+  ck_assert (machine != NULL);
+  ck_assert (err == NULL);
 
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
 
 // test attribute handling in sink names
-static void
-test_bt_sink_machine_settings_wrong_type (BT_TEST_ARGS)
+START_TEST (test_bt_sink_machine_settings_wrong_type)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -131,20 +143,24 @@ test_bt_sink_machine_settings_wrong_type (BT_TEST_ARGS)
 
   GST_INFO ("-- act --");
   GError *err = NULL;
-  BtSinkMachine *machine = bt_sink_machine_new (song, "master", &err);
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "master";
+  
+  BtSinkMachine *machine = bt_sink_machine_new (&cparams, &err);
 
   GST_INFO ("-- assert --");
-  fail_unless (machine != NULL, NULL);
-  fail_unless (err == NULL, NULL);
+  ck_assert (machine != NULL);
+  ck_assert (err == NULL);
 
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
 
 // test attribute handling in sink names
-static void
-test_bt_sink_machine_settings_wrong_parameters (BT_TEST_ARGS)
+START_TEST (test_bt_sink_machine_settings_wrong_parameters)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -152,20 +168,24 @@ test_bt_sink_machine_settings_wrong_parameters (BT_TEST_ARGS)
 
   GST_INFO ("-- act --");
   GError *err = NULL;
-  BtSinkMachine *machine = bt_sink_machine_new (song, "master", &err);
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "master";
+  
+  BtSinkMachine *machine = bt_sink_machine_new (&cparams, &err);
 
   GST_INFO ("-- assert --");
-  fail_unless (machine != NULL, NULL);
-  fail_unless (err == NULL, NULL);
+  ck_assert (machine != NULL);
+  ck_assert (err == NULL);
 
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
 
 // test attribute handling in sink names
-static void
-test_bt_sink_machine_settings_inexistent_type (BT_TEST_ARGS)
+START_TEST (test_bt_sink_machine_settings_inexistent_type)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -173,20 +193,24 @@ test_bt_sink_machine_settings_inexistent_type (BT_TEST_ARGS)
 
   GST_INFO ("-- act --");
   GError *err = NULL;
-  BtSinkMachine *machine = bt_sink_machine_new (song, "master", &err);
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "master";
+  
+  BtSinkMachine *machine = bt_sink_machine_new (&cparams, &err);
 
   GST_INFO ("-- assert --");
-  fail_unless (machine != NULL, NULL);
-  fail_unless (err == NULL, NULL);
+  ck_assert (machine != NULL);
+  ck_assert (err == NULL);
 
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
 
 // test if the song play routine works with fakesink
-static void
-test_bt_sink_machine_play_fakesink (BT_TEST_ARGS)
+START_TEST (test_bt_sink_machine_play_fakesink)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -194,17 +218,17 @@ test_bt_sink_machine_play_fakesink (BT_TEST_ARGS)
   make_test_song ();
 
   /* act & assert */
-  fail_unless (bt_song_play (song), NULL);
+  ck_assert (bt_song_play (song));
   g_usleep (G_USEC_PER_SEC / 10);
   bt_song_stop (song);
 
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
 // the sink machine should fallback on the default device
-static void
-test_bt_sink_machine_play_wrong_parameters (BT_TEST_ARGS)
+START_TEST (test_bt_sink_machine_play_wrong_parameters)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -212,17 +236,17 @@ test_bt_sink_machine_play_wrong_parameters (BT_TEST_ARGS)
   make_test_song ();
 
   /* act & assert */
-  fail_unless (bt_song_play (song), NULL);
+  ck_assert (bt_song_play (song));
   g_usleep (G_USEC_PER_SEC / 10);
   bt_song_stop (song);
 
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
 // the sink machine should fallback to another sink
-static void
-test_bt_sink_machine_play_inexistent_type (BT_TEST_ARGS)
+START_TEST (test_bt_sink_machine_play_inexistent_type)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -231,13 +255,14 @@ test_bt_sink_machine_play_inexistent_type (BT_TEST_ARGS)
   make_test_song ();
 
   /* act & assert */
-  fail_unless (bt_song_play (song), NULL);
+  ck_assert (bt_song_play (song));
   g_usleep (G_USEC_PER_SEC / 10);
   bt_song_stop (song);
 
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
 TCase *
 bt_sink_machine_test_case (void)

--- a/tests/lib/core/t-song-info.c
+++ b/tests/lib/core/t-song-info.c
@@ -52,35 +52,35 @@ case_teardown (void)
 //-- tests
 
 /* apply generic property tests to song-info */
-static void
-test_bt_song_info_properties (BT_TEST_ARGS)
+START_TEST (test_bt_song_info_properties)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
   GObject *song_info = check_gobject_get_object_property (song, "song-info");
 
   /* act & assert */
-  fail_unless (check_gobject_properties (song_info), NULL);
+  ck_assert (check_gobject_properties (song_info));
 
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
 /* create a new song-info with a NULL song object */
-static void
-test_bt_song_info_null_song (BT_TEST_ARGS)
+START_TEST (test_bt_song_info_null_song)
 {
   BT_TEST_START;
   GST_INFO ("-- act --");
   BtSongInfo *song_info = bt_song_info_new (NULL);
 
   GST_INFO ("-- assert --");
-  fail_unless (song_info != NULL, NULL);
+  ck_assert (song_info != NULL);
 
   GST_INFO ("-- cleanup --");
   g_object_unref (song_info);
   BT_TEST_END;
 }
+END_TEST
 
 TCase *
 bt_song_info_test_case (void)

--- a/tests/lib/core/t-song-io-native.c
+++ b/tests/lib/core/t-song-io-native.c
@@ -58,8 +58,7 @@ static gchar *bad_songs[] = {
 };
 
 // load files with errors
-static void
-test_bt_song_io_native_bad_songs (BT_TEST_ARGS)
+START_TEST (test_bt_song_io_native_bad_songs)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -68,18 +67,18 @@ test_bt_song_io_native_bad_songs (BT_TEST_ARGS)
 
   GST_INFO ("-- act & assert --");
   GError *err = NULL;
-  fail_if (bt_song_io_load (song_io, song, &err), NULL);
-  fail_if (err == NULL, NULL);
+  ck_assert (!bt_song_io_load (song_io, song, &err));
+  ck_assert (err != NULL);
 
   GST_INFO ("-- cleanup --");
   g_error_free (err);
   ck_g_object_final_unref (song_io);
   BT_TEST_END;
 }
+END_TEST
 
 // load file into non empty song
-static void
-test_bt_song_io_native_load_twice (BT_TEST_ARGS)
+START_TEST (test_bt_song_io_native_load_twice)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -93,12 +92,13 @@ test_bt_song_io_native_load_twice (BT_TEST_ARGS)
       NULL);
 
   /* act & assert */
-  fail_unless (bt_song_io_load (song_io, song, NULL), NULL);
+  ck_assert (bt_song_io_load (song_io, song, NULL));
 
   GST_INFO ("-- cleanup --");
   ck_g_object_final_unref (song_io);
   BT_TEST_END;
 }
+END_TEST
 
 // not_a_song.abc
 

--- a/tests/lib/core/t-song-io.c
+++ b/tests/lib/core/t-song-io.c
@@ -46,56 +46,56 @@ case_teardown (void)
 //-- tests
 
 // try to create a SongIO object with NULL pointer
-static void
-test_bt_song_io_new_null (BT_TEST_ARGS)
+START_TEST (test_bt_song_io_new_null)
 {
   BT_TEST_START;
   GST_INFO ("-- act --");
   BtSongIO *song_io = bt_song_io_from_file (NULL, NULL);
 
   /*assert */
-  fail_unless (song_io == NULL, NULL);
+  ck_assert (song_io == NULL);
   BT_TEST_END;
 }
+END_TEST
 
 // try to create a SongIO object with empty string
-static void
-test_bt_song_io_new_empty_filename (BT_TEST_ARGS)
+START_TEST (test_bt_song_io_new_empty_filename)
 {
   BT_TEST_START;
   GST_INFO ("-- act --");
   BtSongIO *song_io = bt_song_io_from_file ("", NULL);
 
   /*assert */
-  fail_unless (song_io == NULL, NULL);
+  ck_assert (song_io == NULL);
   BT_TEST_END;
 }
+END_TEST
 
 // try to create a SongIO object from song name without extension
-static void
-test_bt_song_io_new_wrong_filename (BT_TEST_ARGS)
+START_TEST (test_bt_song_io_new_wrong_filename)
 {
   BT_TEST_START;
   GST_INFO ("-- act --");
   BtSongIO *song_io = bt_song_io_from_file ("test", NULL);
 
   /*assert */
-  fail_unless (song_io == NULL, NULL);
+  ck_assert (song_io == NULL);
   BT_TEST_END;
 }
+END_TEST
 
 // try to create a SongIO object from song name with unknown extension
-static void
-test_bt_song_io_new_inexisting_filename (BT_TEST_ARGS)
+START_TEST (test_bt_song_io_new_inexisting_filename)
 {
   BT_TEST_START;
   GST_INFO ("-- act --");
   BtSongIO *song_io = bt_song_io_from_file ("test.unk", NULL);
 
   /*assert */
-  fail_unless (song_io == NULL, NULL);
+  ck_assert (song_io == NULL);
   BT_TEST_END;
 }
+END_TEST
 
 TCase *
 bt_song_io_test_case (void)

--- a/tests/lib/core/t-song.c
+++ b/tests/lib/core/t-song.c
@@ -58,8 +58,7 @@ case_teardown (void)
 
 //-- tests
 
-static void
-test_bt_song_properties (BT_TEST_ARGS)
+START_TEST (test_bt_song_properties)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -72,10 +71,10 @@ test_bt_song_properties (BT_TEST_ARGS)
   ck_g_object_final_unref (song);
   BT_TEST_END;
 }
+END_TEST
 
 // test if the default constructor handles NULL
-static void
-test_bt_song_new_null_app (BT_TEST_ARGS)
+START_TEST (test_bt_song_new_null_app)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -85,17 +84,17 @@ test_bt_song_new_null_app (BT_TEST_ARGS)
   BtSong *song = bt_song_new (NULL);
 
   GST_INFO ("-- assert --");
-  fail_unless (check_has_error_trapped (), NULL);
-  fail_unless (song != NULL, NULL);
+  ck_assert (check_has_error_trapped ());
+  ck_assert (song != NULL);
 
   GST_INFO ("-- cleanup --");
   g_object_unref (song);
   BT_TEST_END;
 }
+END_TEST
 
 // we need the apps bin to actually play
-static void
-test_bt_song_play_empty (BT_TEST_ARGS)
+START_TEST (test_bt_song_play_empty)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -107,17 +106,17 @@ test_bt_song_play_empty (BT_TEST_ARGS)
   bt_song_play (song);
 
   GST_INFO ("-- assert --");
-  fail_unless (check_has_error_trapped (), NULL);
+  ck_assert (check_has_error_trapped ());
 
   GST_INFO ("-- cleanup --");
   bt_song_stop (song);
   ck_g_object_final_unref (song);
   BT_TEST_END;
 }
+END_TEST
 
 // song is null
-static void
-test_bt_song_play_null (BT_TEST_ARGS)
+START_TEST (test_bt_song_play_null)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -128,17 +127,17 @@ test_bt_song_play_null (BT_TEST_ARGS)
   bt_song_play (NULL);
 
   GST_INFO ("-- assert --");
-  fail_unless (check_has_error_trapped (), NULL);
+  ck_assert (check_has_error_trapped ());
 
   GST_INFO ("-- cleanup --");
   bt_song_stop (song);
   ck_g_object_final_unref (song);
   BT_TEST_END;
 }
+END_TEST
 
 // load a new song while the first plays
-static void
-test_bt_song_play_and_load_new (BT_TEST_ARGS)
+START_TEST (test_bt_song_play_and_load_new)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -157,7 +156,7 @@ test_bt_song_play_and_load_new (BT_TEST_ARGS)
       NULL);
 
   GST_INFO ("-- assert --");
-  fail_unless (bt_song_io_load (loader, song, NULL), NULL);
+  ck_assert (bt_song_io_load (loader, song, NULL));
 
   GST_INFO ("-- cleanup --");
   bt_song_stop (song);
@@ -165,6 +164,7 @@ test_bt_song_play_and_load_new (BT_TEST_ARGS)
   ck_g_object_final_unref (song);
   BT_TEST_END;
 }
+END_TEST
 
 TCase *
 bt_song_test_case (void)

--- a/tests/lib/core/t-song.c
+++ b/tests/lib/core/t-song.c
@@ -137,6 +137,9 @@ START_TEST (test_bt_song_play_null)
 END_TEST
 
 // load a new song while the first plays
+//
+// dbeswick: this test has been observed to succeed when run individually,
+// but segfault during a suite run.
 START_TEST (test_bt_song_play_and_load_new)
 {
   BT_TEST_START;

--- a/tests/lib/core/t-source-machine.c
+++ b/tests/lib/core/t-source-machine.c
@@ -53,44 +53,52 @@ case_teardown (void)
 //-- tests
 
 /* create a machine with not exising plugin name */
-static void
-test_bt_source_machine_wrong_name (BT_TEST_ARGS)
+START_TEST (test_bt_source_machine_wrong_name)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
 
   GST_INFO ("-- act --");
   GError *err = NULL;
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "id";
+  
   BtSourceMachine *machine =
-      bt_source_machine_new (song, "id", "nonsense", 1, &err);
+      bt_source_machine_new (&cparams, "nonsense", 1, &err);
 
   GST_INFO ("-- assert --");
-  fail_unless (machine != NULL, NULL);
-  fail_unless (err != NULL, NULL);
+  ck_assert (machine != NULL);
+  ck_assert (err != NULL);
 
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
 /* create a machine which is a sink machine and not a source machine */
-static void
-test_bt_source_machine_wrong_type (BT_TEST_ARGS)
+START_TEST (test_bt_source_machine_wrong_type)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
 
   /*act */
   GError *err = NULL;
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "id";
+  
   BtSourceMachine *machine =
-      bt_source_machine_new (song, "id", "autoaudiosink", 1, &err);
+      bt_source_machine_new (&cparams, "autoaudiosink", 1, &err);
 
   GST_INFO ("-- assert --");
-  fail_unless (machine != NULL, NULL);
-  fail_unless (err != NULL, NULL);
+  ck_assert (machine != NULL);
+  ck_assert (err != NULL);
 
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
 TCase *
 bt_source_machine_test_case (void)

--- a/tests/lib/core/t-tools.c
+++ b/tests/lib/core/t-tools.c
@@ -45,17 +45,16 @@ case_teardown (void)
 
 //-- tests
 
-static void
-test_bt_tools_element_check (BT_TEST_ARGS)
+START_TEST (test_bt_tools_element_check)
 {
   BT_TEST_START;
   GList *list = bt_gst_check_elements (NULL);
-  fail_unless (list == NULL, NULL);
+  ck_assert (list == NULL);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_str_parse_enum_wrong_type (BT_TEST_ARGS)
+START_TEST (test_bt_str_parse_enum_wrong_type)
 {
   BT_TEST_START;
   GST_INFO ("-- act --");
@@ -65,9 +64,9 @@ test_bt_str_parse_enum_wrong_type (BT_TEST_ARGS)
   ck_assert_int_eq (v, -1);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_str_parse_enum_null_str (BT_TEST_ARGS)
+START_TEST (test_bt_str_parse_enum_null_str)
 {
   BT_TEST_START;
   GST_INFO ("-- act --");
@@ -77,21 +76,21 @@ test_bt_str_parse_enum_null_str (BT_TEST_ARGS)
   ck_assert_int_eq (v, -1);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_str_format_enum_wrong_type (BT_TEST_ARGS)
+START_TEST (test_bt_str_format_enum_wrong_type)
 {
   BT_TEST_START;
   GST_INFO ("-- act --");
   const gchar *v = bt_str_format_enum (G_TYPE_INVALID, 1);
 
   /*assert */
-  fail_unless (v == NULL, NULL);
+  ck_assert (v == NULL);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_str_format_enum_wrong_value (BT_TEST_ARGS)
+START_TEST (test_bt_str_format_enum_wrong_value)
 {
   BT_TEST_START;
   GST_INFO ("-- act --");
@@ -99,9 +98,10 @@ test_bt_str_format_enum_wrong_value (BT_TEST_ARGS)
       BT_MACHINE_STATE_COUNT);
 
   /*assert */
-  fail_unless (v == NULL, NULL);
+  ck_assert (v == NULL);
   BT_TEST_END;
 }
+END_TEST
 
 static GstMessage *
 make_msg (void)
@@ -115,8 +115,7 @@ make_msg (void)
   return msg;
 }
 
-static void
-test_bt_log_message_error_wrong_type (BT_TEST_ARGS)
+START_TEST (test_bt_log_message_error_wrong_type)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -127,15 +126,15 @@ test_bt_log_message_error_wrong_type (BT_TEST_ARGS)
       NULL, NULL);
 
   GST_INFO ("-- assert --");
-  fail_if (res, NULL);
+  ck_assert (!res);
 
   GST_INFO ("-- cleanup --");
   gst_message_unref (msg);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_log_message_warning_wrong_type (BT_TEST_ARGS)
+START_TEST (test_bt_log_message_warning_wrong_type)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -146,12 +145,13 @@ test_bt_log_message_warning_wrong_type (BT_TEST_ARGS)
       NULL, NULL);
 
   GST_INFO ("-- assert --");
-  fail_if (res, NULL);
+  ck_assert (!res);
 
   GST_INFO ("-- cleanup --");
   gst_message_unref (msg);
   BT_TEST_END;
 }
+END_TEST
 
 
 TCase *

--- a/tests/lib/core/t-value-group.c
+++ b/tests/lib/core/t-value-group.c
@@ -71,6 +71,8 @@ get_mono_value_group (void)
 
 //-- tests
 
+// dbeswick: this test has been observed to succeed when run individually,
+// but segfault during a suite run.
 START_TEST (test_bt_value_group_get_beyond_size)
 {
   BT_TEST_START;

--- a/tests/lib/core/t-value-group.c
+++ b/tests/lib/core/t-value-group.c
@@ -59,8 +59,11 @@ case_teardown (void)
 static BtValueGroup *
 get_mono_value_group (void)
 {
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "id";
   machine =
-      BT_MACHINE (bt_source_machine_new (song, "id",
+      BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-mono-source", 0, NULL));
   pattern = bt_pattern_new (song, "pattern-name", 4L, machine);
   return bt_pattern_get_global_group (pattern);
@@ -68,23 +71,22 @@ get_mono_value_group (void)
 
 //-- tests
 
-static void
-test_bt_value_group_get_beyond_size (BT_TEST_ARGS)
+START_TEST (test_bt_value_group_get_beyond_size)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
   BtValueGroup *vg = get_mono_value_group ();
 
   /* act && assert */
-  fail_unless (bt_value_group_get_event_data (vg, 100, 100) == NULL, NULL);
+  ck_assert (bt_value_group_get_event_data (vg, 100, 100) == NULL);
 
   GST_INFO ("-- cleanup --");
   g_object_unref (pattern);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_value_group_range_randomize_column_empty_end (BT_TEST_ARGS)
+START_TEST (test_bt_value_group_range_randomize_column_empty_end)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -104,9 +106,9 @@ test_bt_value_group_range_randomize_column_empty_end (BT_TEST_ARGS)
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_value_group_transpose_fine_down_column_clip (BT_TEST_ARGS)
+START_TEST (test_bt_value_group_transpose_fine_down_column_clip)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -125,6 +127,7 @@ test_bt_value_group_transpose_fine_down_column_clip (BT_TEST_ARGS)
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
 
 TCase *

--- a/tests/lib/core/t-wave-table.c
+++ b/tests/lib/core/t-wave-table.c
@@ -52,23 +52,22 @@ case_teardown (void)
 
 //-- tests
 
-static void
-test_bt_wave_table_properties (BT_TEST_ARGS)
+START_TEST (test_bt_wave_table_properties)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
   GObject *wave_table = check_gobject_get_object_property (song, "wavetable");
 
   /* act & assert */
-  fail_unless (check_gobject_properties (wave_table), NULL);
+  ck_assert (check_gobject_properties (wave_table));
 
   GST_INFO ("-- cleanup --");
   g_object_unref (wave_table);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_wave_table_get_beyond_size (BT_TEST_ARGS)
+START_TEST (test_bt_wave_table_get_beyond_size)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -76,12 +75,13 @@ test_bt_wave_table_get_beyond_size (BT_TEST_ARGS)
       (BtWavetable *) check_gobject_get_object_property (song, "wavetable");
 
   /* act & assert */
-  fail_unless (bt_wavetable_get_wave_by_index (wave_table, 1) == NULL, NULL);
+  ck_assert (bt_wavetable_get_wave_by_index (wave_table, 1) == NULL);
 
   GST_INFO ("-- cleanup --");
   g_object_unref (wave_table);
   BT_TEST_END;
 }
+END_TEST
 
 TCase *
 bt_wave_table_test_case (void)

--- a/tests/lib/core/t-wave.c
+++ b/tests/lib/core/t-wave.c
@@ -57,8 +57,7 @@ case_teardown (void)
 
 //-- tests
 
-static void
-test_bt_wave_properties (BT_TEST_ARGS)
+START_TEST (test_bt_wave_properties)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -66,15 +65,15 @@ test_bt_wave_properties (BT_TEST_ARGS)
       1.0, BT_WAVE_LOOP_MODE_OFF, 0);
 
   /* act & assert */
-  fail_unless (check_gobject_properties (wave), NULL);
+  ck_assert (check_gobject_properties (wave));
 
   GST_INFO ("-- cleanup --");
   g_object_unref (wave);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_wave_get_beyond_size (BT_TEST_ARGS)
+START_TEST (test_bt_wave_get_beyond_size)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -82,12 +81,13 @@ test_bt_wave_get_beyond_size (BT_TEST_ARGS)
       BT_WAVE_LOOP_MODE_OFF, 0);
 
   /* act & assert */
-  fail_unless (bt_wave_get_level_by_index (wave, 10) == NULL, NULL);
+  ck_assert (bt_wave_get_level_by_index (wave, 10) == NULL);
 
   GST_INFO ("-- cleanup --");
   g_object_unref (wave);
   BT_TEST_END;
 }
+END_TEST
 
 TCase *
 bt_wave_test_case (void)

--- a/tests/lib/core/t-wire.c
+++ b/tests/lib/core/t-wire.c
@@ -52,56 +52,66 @@ case_teardown (void)
 
 //-- tests
 
-static void
-test_bt_wire_properties (BT_TEST_ARGS)
+START_TEST (test_bt_wire_properties)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
-  BtMachine *src = BT_MACHINE (bt_source_machine_new (song, "gen",
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "gen";
+  BtMachine *src = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-mono-source", 0L, NULL));
+  cparams.id = "proc";
   BtMachine *dst =
-      BT_MACHINE (bt_processor_machine_new (song, "proc", "volume", 0L, NULL));
+      BT_MACHINE (bt_processor_machine_new (&cparams, "volume", 0L, NULL));
   BtWire *wire = bt_wire_new (song, src, dst, NULL);
 
   /* act & assert */
-  fail_unless (check_gobject_properties ((GObject *) wire), NULL);
+  ck_assert (check_gobject_properties ((GObject *) wire));
 
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
 /* create a new wire with NULL for song object */
-static void
-test_bt_wire_new_null_song (BT_TEST_ARGS)
+START_TEST (test_bt_wire_new_null_song)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
-  BtMachine *src = BT_MACHINE (bt_source_machine_new (song, "gen",
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "gen";
+  BtMachine *src = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-mono-source", 0L, NULL));
+  cparams.id = "proc";
   BtMachine *dst =
-      BT_MACHINE (bt_processor_machine_new (song, "proc", "volume", 0L, NULL));
+      BT_MACHINE (bt_processor_machine_new (&cparams, "volume", 0L, NULL));
 
   GST_INFO ("-- act --");
   GError *err = NULL;
   BtWire *wire = bt_wire_new (NULL, src, dst, &err);
 
   GST_INFO ("-- assert --");
-  fail_unless (wire != NULL, NULL);
-  fail_unless (err != NULL, NULL);
+  ck_assert (wire != NULL);
+  ck_assert (err != NULL);
 
   GST_INFO ("-- cleanup --");
   g_object_unref (wire);        // there is no setup to take ownership :/
   g_error_free (err);
   BT_TEST_END;
 }
+END_TEST
 
 /* create a new wire with NULL for the dst machine */
-static void
-test_bt_wire_new_null_machine (BT_TEST_ARGS)
+START_TEST (test_bt_wire_new_null_machine)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
-  BtMachine *src = BT_MACHINE (bt_source_machine_new (song, "gen",
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "gen";
+  BtMachine *src = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-mono-source", 0L, NULL));
 
   GST_INFO ("-- act --");
@@ -109,23 +119,26 @@ test_bt_wire_new_null_machine (BT_TEST_ARGS)
   BtWire *wire = bt_wire_new (song, src, NULL, &err);
 
   GST_INFO ("-- assert --");
-  fail_unless (wire != NULL, NULL);
-  fail_unless (err != NULL, NULL);
+  ck_assert (wire != NULL);
+  ck_assert (err != NULL);
 
   GST_INFO ("-- cleanup --");
   g_error_free (err);
   BT_TEST_END;
 }
+END_TEST
 
 /* create a new wire with the wrong machine type for src */
-static void
-test_bt_wire_new_wrong_src_machine_type (BT_TEST_ARGS)
+START_TEST (test_bt_wire_new_wrong_src_machine_type)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
-  BtMachine *src = BT_MACHINE (bt_source_machine_new (song, "gen",
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "gen";
+  BtMachine *src = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-mono-source", 0L, NULL));
-  BtMachine *dst = BT_MACHINE (bt_source_machine_new (song, "gen",
+  BtMachine *dst = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-mono-source", 0L, NULL));
 
   GST_INFO ("-- act --");
@@ -133,67 +146,77 @@ test_bt_wire_new_wrong_src_machine_type (BT_TEST_ARGS)
   BtWire *wire = bt_wire_new (song, src, dst, &err);
 
   GST_INFO ("-- assert --");
-  fail_unless (wire != NULL, NULL);
-  fail_unless (err != NULL, NULL);
+  ck_assert (wire != NULL);
+  ck_assert (err != NULL);
 
   GST_INFO ("-- cleanup --");
   g_error_free (err);
   BT_TEST_END;
 }
+END_TEST
 
 /* create a new wire with the wrong machine type for dst */
-static void
-test_bt_wire_new_wrong_dst_machine_type (BT_TEST_ARGS)
+START_TEST (test_bt_wire_new_wrong_dst_machine_type)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
-  BtMachine *src = BT_MACHINE (bt_sink_machine_new (song, "master", NULL));
-  BtMachine *dst = BT_MACHINE (bt_sink_machine_new (song, "master", NULL));
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "master";
+  BtMachine *src = BT_MACHINE (bt_sink_machine_new (&cparams, NULL));
+  BtMachine *dst = BT_MACHINE (bt_sink_machine_new (&cparams, NULL));
 
   GST_INFO ("-- act --");
   GError *err = NULL;
   BtWire *wire = bt_wire_new (song, src, dst, &err);
 
   GST_INFO ("-- assert --");
-  fail_unless (wire != NULL, NULL);
-  fail_unless (err != NULL, NULL);
+  ck_assert (wire != NULL);
+  ck_assert (err != NULL);
 
   GST_INFO ("-- cleanup --");
   g_error_free (err);
   BT_TEST_END;
 }
+END_TEST
 
 /* create a wire with the same machine as source and dest */
-static void
-test_bt_wire_same_src_and_dst (BT_TEST_ARGS)
+START_TEST (test_bt_wire_same_src_and_dst)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "id";
   BtMachine *machine =
-      BT_MACHINE (bt_processor_machine_new (song, "id", "volume", 0, NULL));
+      BT_MACHINE (bt_processor_machine_new (&cparams, "volume", 0, NULL));
 
   GST_INFO ("-- act --");
   GError *err = NULL;
   BtWire *wire = bt_wire_new (song, machine, machine, &err);
 
   GST_INFO ("-- assert --");
-  fail_unless (wire != NULL, NULL);
-  fail_unless (err != NULL, NULL);
+  ck_assert (wire != NULL);
+  ck_assert (err != NULL);
 
   GST_INFO ("-- cleanup --");
   g_error_free (err);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_wire_new_twice (BT_TEST_ARGS)
+START_TEST (test_bt_wire_new_twice)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "audiotestsrc";
   BtMachine *src =
-      BT_MACHINE (bt_source_machine_new (song, "audiotestsrc", "audiotestsrc",
+      BT_MACHINE (bt_source_machine_new (&cparams, "audiotestsrc",
           0L, NULL));
-  BtMachine *proc = BT_MACHINE (bt_processor_machine_new (song, "volume",
+  cparams.id = "volume";
+  BtMachine *proc = BT_MACHINE (bt_processor_machine_new (&cparams,
           "volume", 0L, NULL));
   bt_wire_new (song, src, proc, NULL);
 
@@ -202,13 +225,14 @@ test_bt_wire_new_twice (BT_TEST_ARGS)
   BtWire *wire = bt_wire_new (song, src, proc, &err);
 
   GST_INFO ("-- assert --");
-  fail_unless (wire != NULL, NULL);
-  fail_unless (err != NULL, NULL);
+  ck_assert (wire != NULL);
+  ck_assert (err != NULL);
 
   GST_INFO ("-- cleanup --");
   g_error_free (err);
   BT_TEST_END;
 }
+END_TEST
 
 TCase *
 bt_wire_test_case (void)

--- a/tests/lib/gst/e-audiosynth.c
+++ b/tests/lib/gst/e-audiosynth.c
@@ -175,8 +175,7 @@ case_teardown (void)
 
 //-- tests
 
-static void
-test_create_obj (BT_TEST_ARGS)
+START_TEST (test_create_obj)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -185,15 +184,15 @@ test_create_obj (BT_TEST_ARGS)
   GstElement *e = gst_element_factory_make ("buzztrax-test-audio-synth", NULL);
 
   GST_INFO ("-- assert --");
-  fail_unless (e != NULL, NULL);
+  ck_assert (e != NULL);
 
   GST_INFO ("-- cleanup --");
   gst_object_unref (e);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_initialized_with_audio_caps (BT_TEST_ARGS)
+START_TEST (test_initialized_with_audio_caps)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -210,12 +209,12 @@ test_initialized_with_audio_caps (BT_TEST_ARGS)
   gst_bus_poll (bus, GST_MESSAGE_EOS | GST_MESSAGE_ERROR, GST_CLOCK_TIME_NONE);
 
   GST_INFO ("-- assert --");
-  fail_unless (e->caps != NULL, NULL);
+  ck_assert (e->caps != NULL);
   gint i, cs = gst_caps_get_size (e->caps);
-  fail_unless (cs > 0, NULL);
+  ck_assert (cs > 0);
   for (i = 0; i < cs; i++) {
-    fail_unless (gst_structure_has_name (gst_caps_get_structure (e->caps, i),
-            "audio/x-raw"), NULL);
+    ck_assert (gst_structure_has_name (gst_caps_get_structure (e->caps, i),
+            "audio/x-raw"));
   }
 
   GST_INFO ("-- cleanup --");
@@ -224,9 +223,9 @@ test_initialized_with_audio_caps (BT_TEST_ARGS)
   gst_object_unref (p);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_audio_context_configures_buffer_size (BT_TEST_ARGS)
+START_TEST (test_audio_context_configures_buffer_size)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -256,9 +255,9 @@ test_audio_context_configures_buffer_size (BT_TEST_ARGS)
   gst_object_unref (p);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_forward_first_buffer_starts_at_zero (BT_TEST_ARGS)
+START_TEST (test_forward_first_buffer_starts_at_zero)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -276,8 +275,8 @@ test_forward_first_buffer_starts_at_zero (BT_TEST_ARGS)
 
   GST_INFO ("-- assert --");
   BufferFields *bf = get_buffer_info (e, 0);
-  ck_assert_uint64_eq (bf->ts, 0);
-  ck_assert_uint64_eq (bf->offset, 0);
+  ck_assert_uint64_eq (bf->ts, 0L);
+  ck_assert_uint64_eq (bf->offset, 0L);
 
   GST_INFO ("-- cleanup --");
   gst_element_set_state (p, GST_STATE_NULL);
@@ -285,9 +284,9 @@ test_forward_first_buffer_starts_at_zero (BT_TEST_ARGS)
   gst_object_unref (p);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_backwards_last_buffer_ends_at_zero (BT_TEST_ARGS)
+START_TEST (test_backwards_last_buffer_ends_at_zero)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -312,8 +311,8 @@ test_backwards_last_buffer_ends_at_zero (BT_TEST_ARGS)
 
   GST_INFO ("-- assert --");
   BufferFields *bf = get_buffer_info (e, 0);
-  ck_assert_uint64_eq (bf->ts, 0);
-  ck_assert_uint64_eq (bf->offset, 0);
+  ck_assert_uint64_eq (bf->ts, 0L);
+  ck_assert_uint64_eq (bf->offset, 0L);
 
   GST_INFO ("-- cleanup --");
   gst_element_set_state (p, GST_STATE_NULL);
@@ -322,9 +321,9 @@ test_backwards_last_buffer_ends_at_zero (BT_TEST_ARGS)
 
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_buffers_are_contigous (BT_TEST_ARGS)
+START_TEST (test_buffers_are_contigous)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -352,9 +351,9 @@ test_buffers_are_contigous (BT_TEST_ARGS)
   gst_object_unref (p);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_num_buffers_with_stop_pos (BT_TEST_ARGS)
+START_TEST (test_num_buffers_with_stop_pos)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -394,9 +393,9 @@ test_num_buffers_with_stop_pos (BT_TEST_ARGS)
   gst_object_unref (p);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_last_buffer_is_clipped (BT_TEST_ARGS)
+START_TEST (test_last_buffer_is_clipped)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -432,9 +431,9 @@ test_last_buffer_is_clipped (BT_TEST_ARGS)
   gst_object_unref (p);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_no_reset_without_seeks (BT_TEST_ARGS)
+START_TEST (test_no_reset_without_seeks)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -457,9 +456,9 @@ test_no_reset_without_seeks (BT_TEST_ARGS)
   gst_object_unref (p);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_reset_on_seek (BT_TEST_ARGS)
+START_TEST (test_reset_on_seek)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -489,9 +488,9 @@ test_reset_on_seek (BT_TEST_ARGS)
   gst_object_unref (p);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_position_query_time (BT_TEST_ARGS)
+START_TEST (test_position_query_time)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -512,7 +511,7 @@ test_position_query_time (BT_TEST_ARGS)
   gint64 pos;
   gboolean res = gst_element_query_position ((GstElement *) e, GST_FORMAT_TIME,
       &pos);
-  fail_unless (res, NULL);
+  ck_assert (res);
   ck_assert_uint64_eq (bf->duration, pos);
 
   GST_INFO ("-- cleanup --");
@@ -521,6 +520,7 @@ test_position_query_time (BT_TEST_ARGS)
   gst_object_unref (p);
   BT_TEST_END;
 }
+END_TEST
 
 /*
 test buffer metadata in process

--- a/tests/lib/gst/e-combine.c
+++ b/tests/lib/gst/e-combine.c
@@ -39,8 +39,7 @@ case_teardown (void)
 
 //-- tests
 
-static void
-test_create_obj (BT_TEST_ARGS)
+START_TEST (test_create_obj)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -56,10 +55,10 @@ test_create_obj (BT_TEST_ARGS)
   ck_gst_object_final_unref (mix);
   BT_TEST_END;
 }
+END_TEST
 
 // cp /tmp/lt-bt_gst_combine_*.svg docs/reference/bt-gst/images/
-static void
-test_combine_modes (BT_TEST_ARGS)
+START_TEST (test_combine_modes)
 {
   BT_TEST_START;
   gint16 data1[WAVE_SIZE], data2[WAVE_SIZE];
@@ -90,6 +89,7 @@ test_combine_modes (BT_TEST_ARGS)
   ck_gst_object_final_unref (mix);
   BT_TEST_END;
 }
+END_TEST
 
 
 TCase *

--- a/tests/lib/gst/e-combine.c
+++ b/tests/lib/gst/e-combine.c
@@ -48,8 +48,8 @@ START_TEST (test_create_obj)
   GstBtCombine *mix = gstbt_combine_new ();
 
   GST_INFO ("-- assert --");
-  fail_unless (mix != NULL, NULL);
-  fail_unless (G_OBJECT (mix)->ref_count == 1, NULL);
+  ck_assert (mix != NULL);
+  ck_assert (G_OBJECT (mix)->ref_count == 1);
 
   GST_INFO ("-- cleanup --");
   ck_gst_object_final_unref (mix);

--- a/tests/lib/gst/e-elements.c
+++ b/tests/lib/gst/e-elements.c
@@ -58,8 +58,7 @@ static gchar *bt_dec_pipelines[] = {
 
 static gchar *bt_dec_files[] = { "simple2.xml", "simple2.bzt" };
 
-static void
-test_launch_bt_dec (BT_TEST_ARGS)
+START_TEST (test_launch_bt_dec)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -80,7 +79,7 @@ test_launch_bt_dec (BT_TEST_ARGS)
       GST_CLOCK_TIME_NONE);
 
   GST_INFO ("-- assert --");
-  fail_unless (ret == GST_STATE_CHANGE_SUCCESS,
+  ck_assert_msg (ret == GST_STATE_CHANGE_SUCCESS,
       "Couldn't set pipeline to PLAYING: %s",
       gst_element_state_change_return_get_name (ret));
 
@@ -90,12 +89,12 @@ test_launch_bt_dec (BT_TEST_ARGS)
     if (rmessage == tmessage) {
       break;
     } else if (rmessage == GST_MESSAGE_UNKNOWN) {
-      fail ("Unexpected timeout in gst_bus_poll, looking for %d", tmessage);
+      ck_assert_msg (FALSE, "Unexpected timeout in gst_bus_poll, looking for %d", tmessage);
       break;
     } else if (rmessage & message_types) {
       continue;
     }
-    fail ("Unexpected message received of type %d, '%s', looking for %d",
+    ck_assert_msg (FALSE, "Unexpected message received of type %d, '%s', looking for %d",
         rmessage, gst_message_type_get_name (rmessage), tmessage);
   }
 
@@ -106,6 +105,7 @@ test_launch_bt_dec (BT_TEST_ARGS)
   g_free (str);
   BT_TEST_END;
 }
+END_TEST
 
 static gchar *launch_pipelines[] = {
   // synthesizers
@@ -123,8 +123,7 @@ static gchar *launch_pipelines[] = {
   "audiotestsrc num-buffers=10 wave=4 ! bml-libTestBmEffect ! fakesink sync=false"
 };
 
-static void
-test_launch_elements (BT_TEST_ARGS)
+START_TEST (test_launch_elements)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -141,7 +140,7 @@ test_launch_elements (BT_TEST_ARGS)
       GST_CLOCK_TIME_NONE);
 
   GST_INFO ("-- assert --");
-  fail_unless (ret == GST_STATE_CHANGE_SUCCESS,
+  ck_assert_msg (ret == GST_STATE_CHANGE_SUCCESS,
       "Couldn't set pipeline to PLAYING: %s",
       gst_element_state_change_return_get_name (ret));
 
@@ -151,12 +150,12 @@ test_launch_elements (BT_TEST_ARGS)
     if (rmessage == tmessage) {
       break;
     } else if (rmessage == GST_MESSAGE_UNKNOWN) {
-      fail ("Unexpected timeout in gst_bus_poll, looking for %d", tmessage);
+      ck_assert_msg (FALSE, "Unexpected timeout in gst_bus_poll, looking for %d", tmessage);
       break;
     } else if (rmessage & message_types) {
       continue;
     }
-    fail ("Unexpected message received of type %d, '%s', looking for %d",
+    ck_assert_msg (FALSE, "Unexpected message received of type %d, '%s', looking for %d",
         rmessage, gst_message_type_get_name (rmessage), tmessage);
   }
 
@@ -166,6 +165,7 @@ test_launch_elements (BT_TEST_ARGS)
   gst_object_unref (pipeline);
   BT_TEST_END;
 }
+END_TEST
 
 // TODO(ensonic): test with level that all synths produce data
 // TODO(ensonic): if the synth supports presets, test all presets

--- a/tests/lib/gst/e-envelope-ad.c
+++ b/tests/lib/gst/e-envelope-ad.c
@@ -38,8 +38,7 @@ case_teardown (void)
 
 //-- tests
 
-static void
-test_create_obj (BT_TEST_ARGS)
+START_TEST (test_create_obj)
 {
   BT_TEST_START;
   GstBtEnvelopeAD *env;
@@ -49,17 +48,17 @@ test_create_obj (BT_TEST_ARGS)
   env = gstbt_envelope_ad_new ();
 
   GST_INFO ("-- assert --");
-  fail_unless (env != NULL, NULL);
-  fail_unless (G_OBJECT (env)->ref_count == 1, NULL);
+  ck_assert (env != NULL);
+  ck_assert (G_OBJECT (env)->ref_count == 1);
 
   GST_INFO ("-- cleanup --");
   ck_gst_object_final_unref (env);
   BT_TEST_END;
 }
+END_TEST
 
 // cp /tmp/lt-bt_gst_envelope-ad_*.svg docs/reference/bt-gst/images/
-static void
-test_envelope_parameters (BT_TEST_ARGS)
+START_TEST (test_envelope_parameters)
 {
   BT_TEST_START;
   GstBtEnvelopeAD *env;
@@ -85,6 +84,7 @@ test_envelope_parameters (BT_TEST_ARGS)
   ck_gst_object_final_unref (env);
   BT_TEST_END;
 }
+END_TEST
 
 
 TCase *

--- a/tests/lib/gst/e-envelope-adsr.c
+++ b/tests/lib/gst/e-envelope-adsr.c
@@ -38,8 +38,7 @@ case_teardown (void)
 
 //-- tests
 
-static void
-test_create_obj (BT_TEST_ARGS)
+START_TEST (test_create_obj)
 {
   BT_TEST_START;
   GstBtEnvelopeADSR *env;
@@ -49,17 +48,17 @@ test_create_obj (BT_TEST_ARGS)
   env = gstbt_envelope_adsr_new ();
 
   GST_INFO ("-- assert --");
-  fail_unless (env != NULL, NULL);
-  fail_unless (G_OBJECT (env)->ref_count == 1, NULL);
+  ck_assert (env != NULL);
+  ck_assert (G_OBJECT (env)->ref_count == 1);
 
   GST_INFO ("-- cleanup --");
   ck_gst_object_final_unref (env);
   BT_TEST_END;
 }
+END_TEST
 
 // cp /tmp/lt-bt_gst_envelope-adsr_*.svg docs/reference/bt-gst/images/
-static void
-test_envelope_defaults (BT_TEST_ARGS)
+START_TEST (test_envelope_defaults)
 {
   BT_TEST_START;
   GstBtEnvelopeADSR *env;
@@ -81,6 +80,7 @@ test_envelope_defaults (BT_TEST_ARGS)
   ck_gst_object_final_unref (env);
   BT_TEST_END;
 }
+END_TEST
 
 
 TCase *

--- a/tests/lib/gst/e-envelope-d.c
+++ b/tests/lib/gst/e-envelope-d.c
@@ -38,8 +38,7 @@ case_teardown (void)
 
 //-- tests
 
-static void
-test_create_obj (BT_TEST_ARGS)
+START_TEST (test_create_obj)
 {
   BT_TEST_START;
   GstBtEnvelopeD *env;
@@ -49,17 +48,17 @@ test_create_obj (BT_TEST_ARGS)
   env = gstbt_envelope_d_new ();
 
   GST_INFO ("-- assert --");
-  fail_unless (env != NULL, NULL);
-  fail_unless (G_OBJECT (env)->ref_count == 1, NULL);
+  ck_assert (env != NULL);
+  ck_assert (G_OBJECT (env)->ref_count == 1);
 
   GST_INFO ("-- cleanup --");
   ck_gst_object_final_unref (env);
   BT_TEST_END;
 }
+END_TEST
 
 // cp /tmp/lt-bt_gst_envelope-d_*.svg docs/reference/bt-gst/images/
-static void
-test_envelope_curves (BT_TEST_ARGS)
+START_TEST (test_envelope_curves)
 {
   BT_TEST_START;
   GstBtEnvelopeD *env;
@@ -85,6 +84,7 @@ test_envelope_curves (BT_TEST_ARGS)
   ck_gst_object_final_unref (env);
   BT_TEST_END;
 }
+END_TEST
 
 
 TCase *

--- a/tests/lib/gst/e-filter-svf.c
+++ b/tests/lib/gst/e-filter-svf.c
@@ -42,8 +42,7 @@ case_teardown (void)
 
 //-- tests
 
-static void
-test_create_obj (BT_TEST_ARGS)
+START_TEST (test_create_obj)
 {
   BT_TEST_START;
   GstBtFilterSVF *filter;
@@ -53,17 +52,17 @@ test_create_obj (BT_TEST_ARGS)
   filter = gstbt_filter_svf_new ();
 
   GST_INFO ("-- assert --");
-  fail_unless (filter != NULL, NULL);
-  fail_unless (G_OBJECT (filter)->ref_count == 1, NULL);
+  ck_assert (filter != NULL);
+  ck_assert (G_OBJECT (filter)->ref_count == 1);
 
   GST_INFO ("-- cleanup --");
   ck_gst_object_final_unref (filter);
   BT_TEST_END;
 }
+END_TEST
 
 // cp /tmp/lt-bt_gst_filter-svf_*.svg docs/reference/bt-gst/images/
-static void
-test_filter (BT_TEST_ARGS)
+START_TEST (test_filter)
 {
   BT_TEST_START;
   GstBtFilterSVF *filter;
@@ -131,6 +130,7 @@ test_filter (BT_TEST_ARGS)
   ck_gst_object_final_unref (filter);
   BT_TEST_END;
 }
+END_TEST
 
 
 TCase *

--- a/tests/lib/gst/e-osc-synth.c
+++ b/tests/lib/gst/e-osc-synth.c
@@ -38,8 +38,7 @@ case_teardown (void)
 
 //-- tests
 
-static void
-test_create_obj (BT_TEST_ARGS)
+START_TEST (test_create_obj)
 {
   BT_TEST_START;
   GstBtOscSynth *osc;
@@ -49,17 +48,17 @@ test_create_obj (BT_TEST_ARGS)
   osc = gstbt_osc_synth_new ();
 
   GST_INFO ("-- assert --");
-  fail_unless (osc != NULL, NULL);
-  fail_unless (G_OBJECT (osc)->ref_count == 1, NULL);
+  ck_assert (osc != NULL);
+  ck_assert (G_OBJECT (osc)->ref_count == 1);
 
   GST_INFO ("-- cleanup --");
   ck_gst_object_final_unref (osc);
   BT_TEST_END;
 }
+END_TEST
 
 // cp /tmp/lt-bt_gst_osc-synth_*.svg docs/reference/bt-gst/images/
-static void
-test_waves_not_silent (BT_TEST_ARGS)
+START_TEST (test_waves_not_silent)
 {
   BT_TEST_START;
   GstBtOscSynth *osc;
@@ -87,13 +86,14 @@ test_waves_not_silent (BT_TEST_ARGS)
       if (data[j] != 0)
         break;
     }
-    fail_if (j == WAVE_SIZE, "in %s all samples are 0", enum_value->value_name);
+    ck_assert_msg (j != WAVE_SIZE, "in %s all samples are 0", enum_value->value_name);
   }
 
   GST_INFO ("-- cleanup --");
   ck_gst_object_final_unref (osc);
   BT_TEST_END;
 }
+END_TEST
 
 TCase *
 gst_buzztrax_osc_synth_example_case (void)

--- a/tests/lib/gst/e-osc-wave.c
+++ b/tests/lib/gst/e-osc-wave.c
@@ -70,8 +70,7 @@ case_teardown (void)
 
 //-- tests
 
-static void
-test_osc_wave_create_obj (BT_TEST_ARGS)
+START_TEST (test_osc_wave_create_obj)
 {
   BT_TEST_START;
   GstBtOscWave *osc;
@@ -81,16 +80,16 @@ test_osc_wave_create_obj (BT_TEST_ARGS)
   osc = gstbt_osc_wave_new ();
 
   GST_INFO ("-- assert --");
-  fail_unless (osc != NULL, NULL);
-  fail_unless (G_OBJECT (osc)->ref_count == 1, NULL);
+  ck_assert (osc != NULL);
+  ck_assert (G_OBJECT (osc)->ref_count == 1);
 
   GST_INFO ("-- cleanup --");
   ck_gst_object_final_unref (osc);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_osc_wave_is_configured (BT_TEST_ARGS)
+START_TEST (test_osc_wave_is_configured)
 {
   BT_TEST_START;
   GstBtOscWave *osc;
@@ -103,15 +102,15 @@ test_osc_wave_is_configured (BT_TEST_ARGS)
   g_object_set (osc, "wave-callbacks", wave_callbacks, NULL);
 
   GST_INFO ("-- assert --");
-  fail_unless (osc->process != NULL, NULL);
+  ck_assert (osc->process != NULL);
 
   GST_INFO ("-- cleanup --");
   ck_gst_object_final_unref (osc);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_osc_wave_reconfigure (BT_TEST_ARGS)
+START_TEST (test_osc_wave_reconfigure)
 {
   BT_TEST_START;
   GstBtOscWave *osc;
@@ -127,15 +126,15 @@ test_osc_wave_reconfigure (BT_TEST_ARGS)
   g_object_set (osc, "wave-callbacks", stereo_wave_callbacks, NULL);
 
   GST_INFO ("-- assert --");
-  fail_if (osc->process == mono_process_fn, NULL);
+  ck_assert (osc->process != mono_process_fn);
 
   GST_INFO ("-- cleanup --");
   ck_gst_object_final_unref (osc);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_osc_wave_reconfigure_resets (BT_TEST_ARGS)
+START_TEST (test_osc_wave_reconfigure_resets)
 {
   BT_TEST_START;
   GstBtOscWave *osc;
@@ -150,15 +149,15 @@ test_osc_wave_reconfigure_resets (BT_TEST_ARGS)
   g_object_set (osc, "wave-callbacks", no_wave_callbacks, NULL);
 
   GST_INFO ("-- assert --");
-  fail_unless (osc->process == NULL, NULL);
+  ck_assert (osc->process == NULL);
 
   GST_INFO ("-- cleanup --");
   ck_gst_object_final_unref (osc);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_osc_wave_create_mono (BT_TEST_ARGS)
+START_TEST (test_osc_wave_create_mono)
 {
   BT_TEST_START;
   GstBtOscWave *osc;
@@ -182,9 +181,9 @@ test_osc_wave_create_mono (BT_TEST_ARGS)
   ck_gst_object_final_unref (osc);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_osc_wave_create_stereo (BT_TEST_ARGS)
+START_TEST (test_osc_wave_create_stereo)
 {
   BT_TEST_START;
   GstBtOscWave *osc;
@@ -208,9 +207,9 @@ test_osc_wave_create_stereo (BT_TEST_ARGS)
   ck_gst_object_final_unref (osc);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_osc_wave_create_mono_beyond_size (BT_TEST_ARGS)
+START_TEST (test_osc_wave_create_mono_beyond_size)
 {
   BT_TEST_START;
   GstBtOscWave *osc;
@@ -233,9 +232,9 @@ test_osc_wave_create_mono_beyond_size (BT_TEST_ARGS)
   ck_gst_object_final_unref (osc);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_osc_wave_create_stereo_beyond_size (BT_TEST_ARGS)
+START_TEST (test_osc_wave_create_stereo_beyond_size)
 {
   BT_TEST_START;
   GstBtOscWave *osc;
@@ -258,6 +257,7 @@ test_osc_wave_create_stereo_beyond_size (BT_TEST_ARGS)
   ck_gst_object_final_unref (osc);
   BT_TEST_END;
 }
+END_TEST
 
 TCase *
 gst_buzztrax_osc_wave_example_case (void)

--- a/tests/lib/gst/e-tempo.c
+++ b/tests/lib/gst/e-tempo.c
@@ -35,8 +35,7 @@ case_teardown (void)
 
 //-- tests
 
-static void
-test_create_obj (BT_TEST_ARGS)
+START_TEST (test_create_obj)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -45,15 +44,15 @@ test_create_obj (BT_TEST_ARGS)
   GstContext *ctx = gstbt_audio_tempo_context_new (120, 4, 8);
 
   GST_INFO ("-- assert --");
-  fail_unless (ctx != NULL, NULL);
+  ck_assert (ctx != NULL);
 
   GST_INFO ("-- cleanup --");
   gst_context_unref (ctx);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_get_tempo (BT_TEST_ARGS)
+START_TEST (test_get_tempo)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -64,7 +63,7 @@ test_get_tempo (BT_TEST_ARGS)
   gboolean res = gstbt_audio_tempo_context_get_tempo (ctx, &bpm, &tpb, &stpb);
 
   GST_INFO ("-- assert --");
-  fail_unless (res, NULL);
+  ck_assert (res);
   ck_assert_int_eq (bpm, 120);
   ck_assert_int_eq (tpb, 4);
   ck_assert_int_eq (stpb, 8);
@@ -73,6 +72,7 @@ test_get_tempo (BT_TEST_ARGS)
   gst_context_unref (ctx);
   BT_TEST_END;
 }
+END_TEST
 
 TCase *
 gst_buzztrax_tempo_example_case (void)

--- a/tests/lib/gst/e-toneconversion.c
+++ b/tests/lib/gst/e-toneconversion.c
@@ -36,46 +36,45 @@ case_teardown (void)
 
 //-- tests
 
-static void
-test_create_obj (BT_TEST_ARGS)
+START_TEST (test_create_obj)
 {
   BT_TEST_START;
   GstBtToneConversion *n2f;
 
   n2f = gstbt_tone_conversion_new (GSTBT_TONE_CONVERSION_EQUAL_TEMPERAMENT);
-  fail_unless (n2f != NULL, NULL);
-  fail_unless (G_OBJECT (n2f)->ref_count == 1, NULL);
+  ck_assert (n2f != NULL);
+  ck_assert (G_OBJECT (n2f)->ref_count == 1);
 
   // free object
   ck_g_object_final_unref (n2f);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_translate_str_base (BT_TEST_ARGS)
+START_TEST (test_translate_str_base)
 {
   BT_TEST_START;
   GstBtToneConversion *n2f;
   gdouble frq;
 
   n2f = gstbt_tone_conversion_new (GSTBT_TONE_CONVERSION_EQUAL_TEMPERAMENT);
-  fail_unless (n2f != NULL, NULL);
+  ck_assert (n2f != NULL);
 
   frq = gstbt_tone_conversion_translate_from_string (n2f, "A-3");
   //g_print("frq=%lf\n",frq);
-  fail_unless (frq == 440.0, NULL);
+  ck_assert (frq == 440.0);
 
   frq = gstbt_tone_conversion_translate_from_string (n2f, "a-3");
   //g_print("frq=%lf\n",frq);
-  fail_unless (frq == 440.0, NULL);
+  ck_assert (frq == 440.0);
 
   // free object
   ck_g_object_final_unref (n2f);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_translate_str_series (BT_TEST_ARGS)
+START_TEST (test_translate_str_series)
 {
   BT_TEST_START;
   GstBtToneConversion *n2f;
@@ -90,13 +89,13 @@ test_translate_str_series (BT_TEST_ARGS)
   guint i = 0;
 
   n2f = gstbt_tone_conversion_new (_i);
-  fail_unless (n2f != NULL, NULL);
+  ck_assert (n2f != NULL);
 
   while (notes[i]) {
     frq = gstbt_tone_conversion_translate_from_string (n2f, notes[i]);
     //g_print("%s -> frq=%lf\n",notes[i],frq);
-    fail_unless (frq != 0.0, NULL);
-    fail_unless (frq > frq_prev, NULL);
+    ck_assert (frq != 0.0);
+    ck_assert (frq > frq_prev);
     frq_prev = frq;
     i++;
   }
@@ -105,28 +104,28 @@ test_translate_str_series (BT_TEST_ARGS)
   ck_g_object_final_unref (n2f);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_translate_num_base (BT_TEST_ARGS)
+START_TEST (test_translate_num_base)
 {
   BT_TEST_START;
   GstBtToneConversion *n2f;
   gdouble frq;
 
   n2f = gstbt_tone_conversion_new (GSTBT_TONE_CONVERSION_EQUAL_TEMPERAMENT);
-  fail_unless (n2f != NULL, NULL);
+  ck_assert (n2f != NULL);
 
   frq = gstbt_tone_conversion_translate_from_number (n2f, GSTBT_NOTE_A_3);
   //g_print("frq=%lf\n",frq);
-  fail_unless (frq == 440.0, NULL);
+  ck_assert (frq == 440.0);
 
   // free object
   ck_g_object_final_unref (n2f);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_translate_num_series (BT_TEST_ARGS)
+START_TEST (test_translate_num_series)
 {
   BT_TEST_START;
   GstBtToneConversion *n2f;
@@ -134,14 +133,14 @@ test_translate_num_series (BT_TEST_ARGS)
   guint i, j;
 
   n2f = gstbt_tone_conversion_new (_i);
-  fail_unless (n2f != NULL, NULL);
+  ck_assert (n2f != NULL);
 
   for (i = 0; i < 9; i++) {
     for (j = 0; j < 12; j++) {
       frq = gstbt_tone_conversion_translate_from_number (n2f, 1 + (i * 16 + j));
       //g_print("%3u -> frq=%lf\n",i,frq);
-      fail_unless (frq != 0.0, NULL);
-      fail_unless (frq > frq_prev, NULL);
+      ck_assert (frq != 0.0);
+      ck_assert (frq > frq_prev);
       frq_prev = frq;
     }
   }
@@ -150,9 +149,9 @@ test_translate_num_series (BT_TEST_ARGS)
   ck_g_object_final_unref (n2f);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_convert_note_string_2_number (BT_TEST_ARGS)
+START_TEST (test_convert_note_string_2_number)
 {
   BT_TEST_START;
   ck_assert_int_eq (gstbt_tone_conversion_note_string_2_number ("c-0"),
@@ -161,9 +160,9 @@ test_convert_note_string_2_number (BT_TEST_ARGS)
       GSTBT_NOTE_OFF);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_convert_note_number_2_string (BT_TEST_ARGS)
+START_TEST (test_convert_note_number_2_string)
 {
   BT_TEST_START;
   ck_assert_str_eq (gstbt_tone_conversion_note_number_2_string (GSTBT_NOTE_C_0),
@@ -172,9 +171,9 @@ test_convert_note_number_2_string (BT_TEST_ARGS)
       "off");
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_note_number_offset (BT_TEST_ARGS)
+START_TEST (test_note_number_offset)
 {
   BT_TEST_START;
   ck_assert_int_eq (gstbt_tone_conversion_note_number_offset (GSTBT_NOTE_C_0,
@@ -185,6 +184,7 @@ test_note_number_offset (BT_TEST_ARGS)
           10), GSTBT_NOTE_DIS_1);
   BT_TEST_END;
 }
+END_TEST
 
 TCase *
 gst_buzztrax_toneconversion_example_case (void)

--- a/tests/lib/gst/t-elements.c
+++ b/tests/lib/gst/t-elements.c
@@ -106,8 +106,7 @@ case_teardown (void)
 
 //-- tests
 
-static void
-test_state_changes_up_and_down_seq (BT_TEST_ARGS)
+START_TEST (test_state_changes_up_and_down_seq)
 {
   BT_TEST_START;
   GstElement *element;
@@ -118,7 +117,7 @@ test_state_changes_up_and_down_seq (BT_TEST_ARGS)
 
     GST_DEBUG ("testing element %s", name);
     element = gst_element_factory_make (name, name);
-    fail_if (element == NULL, "Could not make element from factory %s", name);
+    ck_assert_msg (element != NULL, "Could not make element from factory %s", name);
 
     if (GST_IS_PIPELINE (element)) {
       GST_DEBUG ("element %s is a pipeline", name);
@@ -139,9 +138,9 @@ test_state_changes_up_and_down_seq (BT_TEST_ARGS)
   }
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_state_changes_up_seq (BT_TEST_ARGS)
+START_TEST (test_state_changes_up_seq)
 {
   BT_TEST_START;
   GstElement *element;
@@ -152,7 +151,7 @@ test_state_changes_up_seq (BT_TEST_ARGS)
 
     GST_INFO ("testing element %s", name);
     element = gst_element_factory_make (name, name);
-    fail_if (element == NULL, "Could not make element from factory %s", name);
+    ck_assert_msg (element != NULL, "Could not make element from factory %s", name);
 
     gst_element_set_state (element, GST_STATE_READY);
 
@@ -169,9 +168,9 @@ test_state_changes_up_seq (BT_TEST_ARGS)
   }
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_state_changes_down_seq (BT_TEST_ARGS)
+START_TEST (test_state_changes_down_seq)
 {
   BT_TEST_START;
   GstElement *element;
@@ -182,7 +181,7 @@ test_state_changes_down_seq (BT_TEST_ARGS)
 
     GST_INFO ("testing element %s", name);
     element = gst_element_factory_make (name, name);
-    fail_if (element == NULL, "Could not make element from factory %s", name);
+    ck_assert_msg (element != NULL, "Could not make element from factory %s", name);
 
     gst_element_set_state (element, GST_STATE_READY);
     gst_element_set_state (element, GST_STATE_PAUSED);
@@ -203,6 +202,7 @@ test_state_changes_down_seq (BT_TEST_ARGS)
   }
   BT_TEST_END;
 }
+END_TEST
 
 TCase *
 gst_buzztrax_elements_test_case (void)

--- a/tests/lib/gst/t-osc-wave.c
+++ b/tests/lib/gst/t-osc-wave.c
@@ -45,8 +45,7 @@ case_teardown (void)
 //-- tests
 
 // no wavetable set, no format negotiated
-static void
-test_osc_wave_create_disconncted (BT_TEST_ARGS)
+START_TEST (test_osc_wave_create_disconncted)
 {
   BT_TEST_START;
   GstBtOscWave *osc;
@@ -57,15 +56,15 @@ test_osc_wave_create_disconncted (BT_TEST_ARGS)
   GST_INFO ("-- act --");
 
   GST_INFO ("-- assert --");
-  fail_unless (osc->process == NULL, NULL);
+  ck_assert (osc->process == NULL);
 
   GST_INFO ("-- cleanup --");
   ck_gst_object_final_unref (osc);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_osc_wave_no_wave (BT_TEST_ARGS)
+START_TEST (test_osc_wave_no_wave)
 {
   BT_TEST_START;
   GstBtOscWave *osc;
@@ -78,12 +77,13 @@ test_osc_wave_no_wave (BT_TEST_ARGS)
   GST_INFO ("-- act --");
 
   GST_INFO ("-- assert --");
-  fail_unless (osc->process == NULL, NULL);
+  ck_assert (osc->process == NULL);
 
   GST_INFO ("-- cleanup --");
   ck_gst_object_final_unref (osc);
   BT_TEST_END;
 }
+END_TEST
 
 TCase *
 gst_buzztrax_osc_wave_test_case (void)

--- a/tests/lib/gst/t-tempo.c
+++ b/tests/lib/gst/t-tempo.c
@@ -35,8 +35,7 @@ case_teardown (void)
 
 //-- tests
 
-static void
-test_null_context (BT_TEST_ARGS)
+START_TEST (test_null_context)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -44,14 +43,14 @@ test_null_context (BT_TEST_ARGS)
   gboolean res = gstbt_audio_tempo_context_get_tempo (NULL, NULL, NULL, NULL);
 
   GST_INFO ("-- assert --");
-  fail_if (res, NULL);
+  ck_assert (!res);
 
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_wrong_context_type (BT_TEST_ARGS)
+START_TEST (test_wrong_context_type)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -61,12 +60,13 @@ test_wrong_context_type (BT_TEST_ARGS)
   gboolean res = gstbt_audio_tempo_context_get_tempo (ctx, NULL, NULL, NULL);
 
   GST_INFO ("-- assert --");
-  fail_if (res, NULL);
+  ck_assert (!(res));
 
   GST_INFO ("-- cleanup --");
   gst_context_unref (ctx);
   BT_TEST_END;
 }
+END_TEST
 
 
 TCase *

--- a/tests/lib/gst/t-toneconversion.c
+++ b/tests/lib/gst/t-toneconversion.c
@@ -36,20 +36,19 @@ case_teardown (void)
 
 //-- tests
 
-static void
-test_translate_str_null (BT_TEST_ARGS)
+START_TEST (test_translate_str_null)
 {
   BT_TEST_START;
   GstBtToneConversion *n2f;
   gdouble frq;
 
   n2f = gstbt_tone_conversion_new (GSTBT_TONE_CONVERSION_EQUAL_TEMPERAMENT);
-  fail_unless (n2f != NULL, NULL);
+  ck_assert (n2f != NULL);
   g_log_set_always_fatal (g_log_set_always_fatal (G_LOG_FATAL_MASK) &
       ~G_LOG_LEVEL_CRITICAL);
 
   frq = gstbt_tone_conversion_translate_from_string (n2f, NULL);
-  fail_unless (frq == 0.0, NULL);
+  ck_assert (frq == 0.0);
 
   g_log_set_always_fatal (g_log_set_always_fatal (G_LOG_FATAL_MASK) |
       G_LOG_LEVEL_CRITICAL);
@@ -57,27 +56,27 @@ test_translate_str_null (BT_TEST_ARGS)
   ck_g_object_final_unref (n2f);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_translate_str_length (BT_TEST_ARGS)
+START_TEST (test_translate_str_length)
 {
   BT_TEST_START;
   GstBtToneConversion *n2f;
   gdouble frq;
 
   n2f = gstbt_tone_conversion_new (GSTBT_TONE_CONVERSION_EQUAL_TEMPERAMENT);
-  fail_unless (n2f != NULL, NULL);
+  ck_assert (n2f != NULL);
   g_log_set_always_fatal (g_log_set_always_fatal (G_LOG_FATAL_MASK) &
       ~G_LOG_LEVEL_CRITICAL);
 
   frq = gstbt_tone_conversion_translate_from_string (n2f, "x");
-  fail_unless (frq == 0.0, NULL);
+  ck_assert (frq == 0.0);
 
   frq = gstbt_tone_conversion_translate_from_string (n2f, "x-");
-  fail_unless (frq == 0.0, NULL);
+  ck_assert (frq == 0.0);
 
   frq = gstbt_tone_conversion_translate_from_string (n2f, "x-000");
-  fail_unless (frq == 0.0, NULL);
+  ck_assert (frq == 0.0);
 
   g_log_set_always_fatal (g_log_set_always_fatal (G_LOG_FATAL_MASK) |
       G_LOG_LEVEL_CRITICAL);
@@ -85,21 +84,21 @@ test_translate_str_length (BT_TEST_ARGS)
   ck_g_object_final_unref (n2f);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_translate_str_delim (BT_TEST_ARGS)
+START_TEST (test_translate_str_delim)
 {
   BT_TEST_START;
   GstBtToneConversion *n2f;
   gdouble frq;
 
   n2f = gstbt_tone_conversion_new (GSTBT_TONE_CONVERSION_EQUAL_TEMPERAMENT);
-  fail_unless (n2f != NULL, NULL);
+  ck_assert (n2f != NULL);
   g_log_set_always_fatal (g_log_set_always_fatal (G_LOG_FATAL_MASK) &
       ~G_LOG_LEVEL_CRITICAL);
 
   frq = gstbt_tone_conversion_translate_from_string (n2f, "C+3");
-  fail_unless (frq == 0.0, NULL);
+  ck_assert (frq == 0.0);
 
   g_log_set_always_fatal (g_log_set_always_fatal (G_LOG_FATAL_MASK) |
       G_LOG_LEVEL_CRITICAL);
@@ -107,21 +106,21 @@ test_translate_str_delim (BT_TEST_ARGS)
   ck_g_object_final_unref (n2f);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_translate_enum_range (BT_TEST_ARGS)
+START_TEST (test_translate_enum_range)
 {
   BT_TEST_START;
   GstBtToneConversion *n2f;
   gdouble frq;
 
   n2f = gstbt_tone_conversion_new (GSTBT_TONE_CONVERSION_EQUAL_TEMPERAMENT);
-  fail_unless (n2f != NULL, NULL);
+  ck_assert (n2f != NULL);
   g_log_set_always_fatal (g_log_set_always_fatal (G_LOG_FATAL_MASK) &
       ~G_LOG_LEVEL_CRITICAL);
 
   frq = gstbt_tone_conversion_translate_from_number (n2f, 1 + (16 * 10));
-  fail_unless (frq == 0.0, NULL);
+  ck_assert (frq == 0.0);
 
   g_log_set_always_fatal (g_log_set_always_fatal (G_LOG_FATAL_MASK) |
       G_LOG_LEVEL_CRITICAL);
@@ -129,6 +128,7 @@ test_translate_enum_range (BT_TEST_ARGS)
   ck_g_object_final_unref (n2f);
   BT_TEST_END;
 }
+END_TEST
 
 TCase *
 gst_buzztrax_toneconversion_test_case (void)

--- a/tests/lib/ic/e-aseq-discoverer.c
+++ b/tests/lib/ic/e-aseq-discoverer.c
@@ -65,8 +65,7 @@ case_teardown (void)
 
 //-- tests
 
-static void
-test_btic_initial_aseq_device_discovered (BT_TEST_ARGS)
+START_TEST (test_btic_initial_aseq_device_discovered)
 {
   BT_TEST_START;
   if (!seq)
@@ -78,15 +77,15 @@ test_btic_initial_aseq_device_discovered (BT_TEST_ARGS)
       btic_registry_get_device_by_name ("alsa sequencer: test-static");
 
   GST_INFO ("-- assert --");
-  fail_unless (device != NULL, NULL);
+  ck_assert (device != NULL);
 
   GST_INFO ("-- cleanup --");
   g_object_unref (device);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_btic_new_aseq_device_discovered (BT_TEST_ARGS)
+START_TEST (test_btic_new_aseq_device_discovered)
 {
   BT_TEST_START;
   if (!seq)
@@ -103,16 +102,16 @@ test_btic_new_aseq_device_discovered (BT_TEST_ARGS)
       btic_registry_get_device_by_name ("alsa sequencer: test-dynamic1");
 
   GST_INFO ("-- assert --");
-  fail_unless (device != NULL, NULL);
+  ck_assert (device != NULL);
 
   GST_INFO ("-- cleanup --");
   g_object_unref (device);
   snd_seq_delete_port (seq, port);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_btic_removed_aseq_device_discovered (BT_TEST_ARGS)
+START_TEST (test_btic_removed_aseq_device_discovered)
 {
   BT_TEST_START;
   if (!seq)
@@ -130,12 +129,13 @@ test_btic_removed_aseq_device_discovered (BT_TEST_ARGS)
       btic_registry_get_device_by_name ("alsa sequencer: test-dynamic2");
 
   GST_INFO ("-- assert --");
-  fail_unless (device == NULL, NULL);
+  ck_assert (device == NULL);
 
   GST_INFO ("-- cleanup --");
   g_object_unref (device);
   BT_TEST_END;
 }
+END_TEST
 
 TCase *
 bt_aseq_discoverer_example_case (void)

--- a/tests/lib/ic/e-device.c
+++ b/tests/lib/ic/e-device.c
@@ -49,8 +49,7 @@ case_teardown (void)
 
 //-- tests
 
-static void
-test_btic_device_lookup (BT_TEST_ARGS)
+START_TEST (test_btic_device_lookup)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -59,15 +58,15 @@ test_btic_device_lookup (BT_TEST_ARGS)
   BtIcDevice *device = btic_registry_get_device_by_name ("test");
 
   GST_INFO ("-- assert --");
-  fail_unless (device != NULL, NULL);
+  ck_assert (device != NULL);
 
   GST_INFO ("-- cleanup --");
   g_object_unref (device);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_btic_device_has_controls (BT_TEST_ARGS)
+START_TEST (test_btic_device_has_controls)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -77,15 +76,15 @@ test_btic_device_has_controls (BT_TEST_ARGS)
   gboolean has_controls = btic_device_has_controls (device);
 
   GST_INFO ("-- assert --");
-  fail_unless (has_controls, NULL);
+  ck_assert (has_controls);
 
   GST_INFO ("-- cleanup --");
   g_object_unref (device);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_btic_device_get_control_by_name (BT_TEST_ARGS)
+START_TEST (test_btic_device_get_control_by_name)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -95,16 +94,16 @@ test_btic_device_get_control_by_name (BT_TEST_ARGS)
   BtIcControl *control = btic_device_get_control_by_name (device, "abs1");
 
   GST_INFO ("-- assert --");
-  fail_unless (control != NULL, NULL);
+  ck_assert (control != NULL);
 
   GST_INFO ("-- cleanup --");
   g_object_unref (control);
   g_object_unref (device);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_btic_device_get_control_by_id (BT_TEST_ARGS)
+START_TEST (test_btic_device_get_control_by_id)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -114,13 +113,14 @@ test_btic_device_get_control_by_id (BT_TEST_ARGS)
   BtIcControl *control = btic_device_get_control_by_id (device, 0);
 
   GST_INFO ("-- assert --");
-  fail_unless (control != NULL, NULL);
+  ck_assert (control != NULL);
 
   GST_INFO ("-- cleanup --");
   g_object_unref (control);
   g_object_unref (device);
   BT_TEST_END;
 }
+END_TEST
 
 TCase *
 bt_device_example_case (void)

--- a/tests/lib/ic/e-ic.c
+++ b/tests/lib/ic/e-ic.c
@@ -52,28 +52,27 @@ case_teardown (void)
 //-- tests
 
 // test if the normal init call works with commandline arguments (no args)
-static void
-test_btic_init_no_args (BT_TEST_ARGS)
+START_TEST (test_btic_init_no_args)
 {
   BT_TEST_START;
   GST_INFO ("-- act --");
   btic_init (&test_argc, &test_argvptr);
   BT_TEST_END;
 }
+END_TEST
 
 // test if the init call handles correct null pointers
-static void
-test_btic_init_nullptr_args (BT_TEST_ARGS)
+START_TEST (test_btic_init_nullptr_args)
 {
   BT_TEST_START;
   GST_INFO ("-- act --");
   btic_init (NULL, NULL);
   BT_TEST_END;
 }
+END_TEST
 
 // test if the normal init call works with commandline arguments
-static void
-test_btic_init_args (BT_TEST_ARGS)
+START_TEST (test_btic_init_args)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -86,10 +85,11 @@ test_btic_init_args (BT_TEST_ARGS)
 
   GST_INFO ("-- assert --");
   ck_assert_int_eq (test_argc, 1);
-  fail_unless (check_file_contains_str (stdout, NULL,
-          "libbuzztrax-ic-" BT_VERSION " from " PACKAGE_STRING), NULL);
+  ck_assert (check_file_contains_str (stdout, NULL,
+          "libbuzztrax-ic-" BT_VERSION " from " PACKAGE_STRING));
   BT_TEST_END;
 }
+END_TEST
 
 TCase *
 bt_ic_example_case (void)

--- a/tests/lib/ic/e-learn.c
+++ b/tests/lib/ic/e-learn.c
@@ -49,8 +49,7 @@ case_teardown (void)
 
 //-- tests
 
-static void
-test_btic_learn_register_control (BT_TEST_ARGS)
+START_TEST (test_btic_learn_register_control)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -61,15 +60,15 @@ test_btic_learn_register_control (BT_TEST_ARGS)
       btic_learn_register_learned_control (BTIC_LEARN (device), "learn1");
 
   GST_INFO ("-- assert --");
-  fail_unless (control != NULL, NULL);
+  ck_assert (control != NULL);
 
   GST_INFO ("-- cleanup --");
   g_object_unref (device);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_btic_learn_store_controls (BT_TEST_ARGS)
+START_TEST (test_btic_learn_store_controls)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -87,6 +86,7 @@ test_btic_learn_store_controls (BT_TEST_ARGS)
   g_object_unref (device);
   BT_TEST_END;
 }
+END_TEST
 
 TCase *
 bt_learn_example_case (void)

--- a/tests/lib/ic/e-registry.c
+++ b/tests/lib/ic/e-registry.c
@@ -45,8 +45,7 @@ case_teardown (void)
 
 //-- tests
 
-static void
-test_btic_registry_create (BT_TEST_ARGS)
+START_TEST (test_btic_registry_create)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -55,15 +54,15 @@ test_btic_registry_create (BT_TEST_ARGS)
   BtIcRegistry *registry = btic_registry_new ();
 
   GST_INFO ("-- assert --");
-  fail_unless (registry != NULL, NULL);
+  ck_assert (registry != NULL);
 
   GST_INFO ("-- cleanup --");
   ck_g_object_final_unref (registry);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_btic_registry_not_empty (BT_TEST_ARGS)
+START_TEST (test_btic_registry_not_empty)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -75,16 +74,16 @@ test_btic_registry_not_empty (BT_TEST_ARGS)
       (GList *) check_gobject_get_ptr_property (registry, "devices");
 
   GST_INFO ("-- assert --");
-  fail_unless (devices != NULL, NULL);
+  ck_assert (devices != NULL);
   ck_assert_int_gt (g_list_length (devices), 0);
 
   GST_INFO ("-- cleanup --");
   ck_g_object_final_unref (registry);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_btic_registry_get_device_by_name (BT_TEST_ARGS)
+START_TEST (test_btic_registry_get_device_by_name)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -95,13 +94,14 @@ test_btic_registry_get_device_by_name (BT_TEST_ARGS)
   BtIcDevice *device = btic_registry_get_device_by_name ("test");
 
   GST_INFO ("-- assert --");
-  fail_unless (device != NULL, NULL);
+  ck_assert (device != NULL);
 
   GST_INFO ("-- cleanup --");
   g_object_unref (device);
   ck_g_object_final_unref (registry);
   BT_TEST_END;
 }
+END_TEST
 
 TCase *
 bt_registry_example_case (void)

--- a/tests/lib/ic/t-ic.c
+++ b/tests/lib/ic/t-ic.c
@@ -52,8 +52,7 @@ case_teardown (void)
 //-- tests
 
 // test init with wrong arg usage
-static void
-test_btic_core_init_bad_arg_value (BT_TEST_ARGS)
+START_TEST (test_btic_core_init_bad_arg_value)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -67,10 +66,10 @@ test_btic_core_init_bad_arg_value (BT_TEST_ARGS)
   GST_INFO ("-- assert --");
   BT_TEST_END;
 }
+END_TEST
 
 // test init with nonsense args
-static void
-test_btic_core_init_bad_arg (BT_TEST_ARGS)
+START_TEST (test_btic_core_init_bad_arg)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -91,9 +90,9 @@ test_btic_core_init_bad_arg (BT_TEST_ARGS)
   g_option_context_free (ctx);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_btic_core_init_bad_arg_exits (BT_TEST_ARGS)
+START_TEST (test_btic_core_init_bad_arg_exits)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -107,6 +106,7 @@ test_btic_core_init_bad_arg_exits (BT_TEST_ARGS)
   GST_INFO ("-- assert --");
   BT_TEST_END;
 }
+END_TEST
 
 TCase *
 bt_ic_test_case (void)

--- a/tests/lib/ic/t-registry.c
+++ b/tests/lib/ic/t-registry.c
@@ -46,8 +46,7 @@ case_teardown (void)
 
 //-- tests
 
-static void
-test_btic_registry_unknown_device (BT_TEST_ARGS)
+START_TEST (test_btic_registry_unknown_device)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -58,12 +57,13 @@ test_btic_registry_unknown_device (BT_TEST_ARGS)
   BtIcDevice *device = btic_registry_get_device_by_name ("unknown-device");
 
   GST_INFO ("-- assert --");
-  fail_unless (device == NULL, NULL);
+  ck_assert (device == NULL);
 
   GST_INFO ("-- cleanup --");
   ck_g_object_final_unref (registry);
   BT_TEST_END;
 }
+END_TEST
 
 
 TCase *

--- a/tests/ui/cmd/e-cmd-application.c
+++ b/tests/ui/cmd/e-cmd-application.c
@@ -46,8 +46,7 @@ case_teardown (void)
 
 //-- tests
 
-static void
-test_bt_cmd_application_create (BT_TEST_ARGS)
+START_TEST (test_bt_cmd_application_create)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -56,16 +55,16 @@ test_bt_cmd_application_create (BT_TEST_ARGS)
   BtCmdApplication *app = bt_cmd_application_new (TRUE);
 
   GST_INFO ("-- assert --");
-  fail_unless (app != NULL, NULL);
+  ck_assert (app != NULL);
   ck_assert_int_eq (G_OBJECT_REF_COUNT (app), 1);
 
   GST_INFO ("-- cleanup --");
   ck_g_object_final_unref (app);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_cmd_application_play (BT_TEST_ARGS)
+START_TEST (test_bt_cmd_application_play)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -76,15 +75,15 @@ test_bt_cmd_application_play (BT_TEST_ARGS)
       check_get_test_song_path ("test-simple1.xml"));
 
   GST_INFO ("-- assert --");
-  fail_unless (ret == TRUE, NULL);
+  ck_assert (ret == TRUE);
 
   GST_INFO ("-- cleanup --");
   ck_g_object_final_unref (app);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_cmd_application_play_two_files (BT_TEST_ARGS)
+START_TEST (test_bt_cmd_application_play_two_files)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -96,15 +95,15 @@ test_bt_cmd_application_play_two_files (BT_TEST_ARGS)
       check_get_test_song_path ("test-simple2.xml"));
 
   GST_INFO ("-- assert --");
-  fail_unless (ret == TRUE, NULL);
+  ck_assert (ret == TRUE);
 
   GST_INFO ("-- cleanup --");
   ck_g_object_final_unref (app);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_cmd_application_play_incomplete_file (BT_TEST_ARGS)
+START_TEST (test_bt_cmd_application_play_incomplete_file)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -116,15 +115,15 @@ test_bt_cmd_application_play_incomplete_file (BT_TEST_ARGS)
 
   GST_INFO ("-- assert --");
   // we should still attempt to play it
-  fail_unless (ret == TRUE, NULL);
+  ck_assert (ret == TRUE);
 
   GST_INFO ("-- cleanup --");
   ck_g_object_final_unref (app);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_cmd_application_info (BT_TEST_ARGS)
+START_TEST (test_bt_cmd_application_info)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -137,9 +136,9 @@ test_bt_cmd_application_info (BT_TEST_ARGS)
       check_get_test_song_path ("test-simple1.xml"), tmp_file_name);
 
   GST_INFO ("-- assert --");
-  fail_unless (ret == TRUE, NULL);
-  fail_unless (check_file_contains_str (NULL, tmp_file_name,
-          "song.song_info.name: \"test simple 1\""), NULL);
+  ck_assert (ret == TRUE);
+  ck_assert (check_file_contains_str (NULL, tmp_file_name,
+          "song.song_info.name: \"test simple 1\""));
 
   GST_INFO ("-- cleanup --");
   g_unlink (tmp_file_name);
@@ -147,9 +146,9 @@ test_bt_cmd_application_info (BT_TEST_ARGS)
   ck_g_object_final_unref (app);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_cmd_application_info_for_incomplete_file (BT_TEST_ARGS)
+START_TEST (test_bt_cmd_application_info_for_incomplete_file)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -162,13 +161,13 @@ test_bt_cmd_application_info_for_incomplete_file (BT_TEST_ARGS)
       check_get_test_song_path ("broken2.xml"), tmp_file_name);
 
   GST_INFO ("-- assert --");
-  fail_unless (ret == TRUE, NULL);
-  fail_unless (check_file_contains_str (NULL, tmp_file_name,
-          "song.song_info.name: \"broken 2\""), NULL);
-  fail_unless (check_file_contains_str (NULL, tmp_file_name,
-          "song.setup.number_of_missing_machines: 1"), NULL);
-  fail_unless (check_file_contains_str (NULL, tmp_file_name,
-          "song.wavetable.number_of_missing_waves: 2"), NULL);
+  ck_assert (ret == TRUE);
+  ck_assert (check_file_contains_str (NULL, tmp_file_name,
+          "song.song_info.name: \"broken 2\""));
+  ck_assert (check_file_contains_str (NULL, tmp_file_name,
+          "song.setup.number_of_missing_machines: 1"));
+  ck_assert (check_file_contains_str (NULL, tmp_file_name,
+          "song.wavetable.number_of_missing_waves: 2"));
 
   GST_INFO ("-- cleanup --");
   g_unlink (tmp_file_name);
@@ -176,6 +175,7 @@ test_bt_cmd_application_info_for_incomplete_file (BT_TEST_ARGS)
   ck_g_object_final_unref (app);
   BT_TEST_END;
 }
+END_TEST
 
 TCase *
 bt_cmd_application_example_case (void)

--- a/tests/ui/cmd/t-cmd-application.c
+++ b/tests/ui/cmd/t-cmd-application.c
@@ -50,8 +50,7 @@ static gchar *bad_files[] = {
 //-- tests
 
 // tests if the play method works without exceptions if we put NULL as filename.
-static void
-test_bt_cmd_application_play_null_as_filename (BT_TEST_ARGS)
+START_TEST (test_bt_cmd_application_play_null_as_filename)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -63,17 +62,17 @@ test_bt_cmd_application_play_null_as_filename (BT_TEST_ARGS)
   gboolean ret = bt_cmd_application_play (app, NULL);
 
   GST_INFO ("-- assert --");
-  fail_unless (check_has_error_trapped (), NULL);
-  fail_unless (ret == FALSE, NULL);
+  ck_assert (check_has_error_trapped ());
+  ck_assert (ret == FALSE);
 
   GST_INFO ("-- cleanup --");
   ck_g_object_final_unref (app);
   BT_TEST_END;
 }
+END_TEST
 
 // file not found test. this is a negative test
-static void
-test_bt_cmd_application_play_non_existing_file (BT_TEST_ARGS)
+START_TEST (test_bt_cmd_application_play_non_existing_file)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -85,16 +84,16 @@ test_bt_cmd_application_play_non_existing_file (BT_TEST_ARGS)
   gboolean ret = bt_cmd_application_play (app, "");
 
   GST_INFO ("-- assert --");
-  fail_unless (check_has_error_trapped (), NULL);
-  fail_unless (ret == FALSE, NULL);
+  ck_assert (check_has_error_trapped ());
+  ck_assert (ret == FALSE);
 
   GST_INFO ("-- cleanup --");
   ck_g_object_final_unref (app);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_cmd_application_play_bad_file (BT_TEST_ARGS)
+START_TEST (test_bt_cmd_application_play_bad_file)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -105,16 +104,16 @@ test_bt_cmd_application_play_bad_file (BT_TEST_ARGS)
       check_get_test_song_path (bad_files[_i]));
 
   GST_INFO ("-- assert --");
-  fail_unless (ret == FALSE, NULL);
+  ck_assert (ret == FALSE);
 
   GST_INFO ("-- cleanup --");
   ck_g_object_final_unref (app);
   BT_TEST_END;
 }
+END_TEST
 
 // test if the info method works with NULL argument for the filename,
-static void
-test_bt_cmd_application_info_null_as_filename (BT_TEST_ARGS)
+START_TEST (test_bt_cmd_application_info_null_as_filename)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -126,17 +125,17 @@ test_bt_cmd_application_info_null_as_filename (BT_TEST_ARGS)
   gboolean ret = bt_cmd_application_info (app, NULL, NULL);
 
   GST_INFO ("-- assert --");
-  fail_unless (check_has_error_trapped (), NULL);
-  fail_unless (ret == FALSE, NULL);
+  ck_assert (check_has_error_trapped ());
+  ck_assert (ret == FALSE);
 
   GST_INFO ("-- cleanup --");
   ck_g_object_final_unref (app);
   BT_TEST_END;
 }
+END_TEST
 
 // test if the info method works with a empty filename.
-static void
-test_bt_cmd_application_info_non_existing_file (BT_TEST_ARGS)
+START_TEST (test_bt_cmd_application_info_non_existing_file)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -148,16 +147,16 @@ test_bt_cmd_application_info_non_existing_file (BT_TEST_ARGS)
   gboolean ret = bt_cmd_application_info (app, "", NULL);
 
   GST_INFO ("-- assert --");
-  fail_unless (check_has_error_trapped (), NULL);
-  fail_unless (ret == FALSE, NULL);
+  ck_assert (check_has_error_trapped ());
+  ck_assert (ret == FALSE);
 
   GST_INFO ("-- cleanup --");
   ck_g_object_final_unref (app);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_cmd_application_info_bad_file (BT_TEST_ARGS)
+START_TEST (test_bt_cmd_application_info_bad_file)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -168,12 +167,13 @@ test_bt_cmd_application_info_bad_file (BT_TEST_ARGS)
       check_get_test_song_path (bad_files[_i]), NULL);
 
   GST_INFO ("-- assert --");
-  fail_unless (ret == FALSE, NULL);
+  ck_assert (ret == FALSE);
 
   GST_INFO ("-- cleanup --");
   ck_g_object_final_unref (app);
   BT_TEST_END;
 }
+END_TEST
 
 TCase *
 bt_cmd_application_test_case (void)

--- a/tests/ui/edit/e-about-dialog.c
+++ b/tests/ui/edit/e-about-dialog.c
@@ -58,8 +58,7 @@ case_teardown (void)
 //-- tests
 
 // create app and then unconditionally destroy window
-static void
-test_bt_about_dialog_create (BT_TEST_ARGS)
+START_TEST (test_bt_about_dialog_create)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -68,7 +67,7 @@ test_bt_about_dialog_create (BT_TEST_ARGS)
   GtkWidget *dialog = GTK_WIDGET (bt_about_dialog_new ());
 
   GST_INFO ("-- assert --");
-  fail_unless (dialog != NULL, NULL);
+  ck_assert (dialog != NULL);
   gtk_widget_show_all (dialog);
   check_make_widget_screenshot (GTK_WIDGET (dialog), NULL);
 
@@ -76,6 +75,7 @@ test_bt_about_dialog_create (BT_TEST_ARGS)
   gtk_widget_destroy (dialog);
   BT_TEST_END;
 }
+END_TEST
 
 TCase *
 bt_about_dialog_example_case (void)

--- a/tests/ui/edit/e-change-log.c
+++ b/tests/ui/edit/e-change-log.c
@@ -178,8 +178,7 @@ case_teardown (void)
 //-- tests
 
 // test lifecycle/refcounts
-static void
-test_bt_change_log_create_and_destroy (BT_TEST_ARGS)
+START_TEST (test_bt_change_log_create_and_destroy)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -188,15 +187,15 @@ test_bt_change_log_create_and_destroy (BT_TEST_ARGS)
   BtChangeLog *cl = bt_change_log_new ();
 
   GST_INFO ("-- assert --");
-  fail_unless (cl != NULL, NULL);
+  ck_assert (cl != NULL);
 
   GST_INFO ("-- cleanup --");
   g_object_unref (cl);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_change_log_initial_undo_redo_state (BT_TEST_ARGS)
+START_TEST (test_bt_change_log_initial_undo_redo_state)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -207,16 +206,16 @@ test_bt_change_log_initial_undo_redo_state (BT_TEST_ARGS)
   g_object_get (cl, "can-undo", &can_undo, "can-redo", &can_redo, NULL);
 
   GST_INFO ("-- assert --");
-  fail_unless (!can_undo, NULL);
-  fail_unless (!can_redo, NULL);
+  ck_assert (!can_undo);
+  ck_assert (!can_redo);
 
   GST_INFO ("-- cleanup --");
   g_object_unref (cl);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_change_log_undo_redo_state_after_single_change (BT_TEST_ARGS)
+START_TEST (test_bt_change_log_undo_redo_state_after_single_change)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -229,17 +228,17 @@ test_bt_change_log_undo_redo_state_after_single_change (BT_TEST_ARGS)
   g_object_get (cl, "can-undo", &can_undo, "can-redo", &can_redo, NULL);
 
   GST_INFO ("-- assert --");
-  fail_unless (can_undo, NULL);
-  fail_unless (!can_redo, NULL);
+  ck_assert (can_undo);
+  ck_assert (!can_redo);
 
   GST_INFO ("-- cleanup --");
   g_object_unref (tcl);
   g_object_unref (cl);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_change_log_undo_redo_state_single_change_after_undo (BT_TEST_ARGS)
+START_TEST (test_bt_change_log_undo_redo_state_single_change_after_undo)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -253,17 +252,17 @@ test_bt_change_log_undo_redo_state_single_change_after_undo (BT_TEST_ARGS)
   g_object_get (cl, "can-undo", &can_undo, "can-redo", &can_redo, NULL);
 
   GST_INFO ("-- assert --");
-  fail_unless (!can_undo, NULL);
-  fail_unless (can_redo, NULL);
+  ck_assert (!can_undo);
+  ck_assert (can_redo);
 
   GST_INFO ("-- cleanup --");
   g_object_unref (tcl);
   g_object_unref (cl);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_change_log_undo_redo_state_single_change_after_redo (BT_TEST_ARGS)
+START_TEST (test_bt_change_log_undo_redo_state_single_change_after_redo)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -278,17 +277,17 @@ test_bt_change_log_undo_redo_state_single_change_after_redo (BT_TEST_ARGS)
   g_object_get (cl, "can-undo", &can_undo, "can-redo", &can_redo, NULL);
 
   GST_INFO ("-- assert --");
-  fail_unless (can_undo, NULL);
-  fail_unless (!can_redo, NULL);
+  ck_assert (can_undo);
+  ck_assert (!can_redo);
 
   GST_INFO ("-- cleanup --");
   g_object_unref (tcl);
   g_object_unref (cl);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_change_log_undo_redo_state_double_change_after_undo (BT_TEST_ARGS)
+START_TEST (test_bt_change_log_undo_redo_state_double_change_after_undo)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -303,19 +302,19 @@ test_bt_change_log_undo_redo_state_double_change_after_undo (BT_TEST_ARGS)
   g_object_get (cl, "can-undo", &can_undo, "can-redo", &can_redo, NULL);
 
   GST_INFO ("-- assert --");
-  fail_unless (can_undo, NULL);
-  fail_unless (can_redo, NULL);
+  ck_assert (can_undo);
+  ck_assert (can_redo);
 
   GST_INFO ("-- cleanup --");
   g_object_unref (tcl);
   g_object_unref (cl);
   BT_TEST_END;
 }
+END_TEST
 
 
 // test truncating the undo/redo stack
-static void
-test_bt_change_log_undo_redo_state_stack_trunc (BT_TEST_ARGS)
+START_TEST (test_bt_change_log_undo_redo_state_stack_trunc)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -330,18 +329,18 @@ test_bt_change_log_undo_redo_state_stack_trunc (BT_TEST_ARGS)
   g_object_get (cl, "can-undo", &can_undo, "can-redo", &can_redo, NULL);
 
   GST_INFO ("-- assert --");
-  fail_unless (can_undo, NULL);
-  fail_unless (!can_redo, NULL);
+  ck_assert (can_undo);
+  ck_assert (!can_redo);
 
   GST_INFO ("-- cleanup --");
   g_object_unref (tcl);
   g_object_unref (cl);
   BT_TEST_END;
 }
+END_TEST
 
 // test single undo/redo actions
-static void
-test_bt_change_log_single_change_after_undo (BT_TEST_ARGS)
+START_TEST (test_bt_change_log_single_change_after_undo)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -360,10 +359,10 @@ test_bt_change_log_single_change_after_undo (BT_TEST_ARGS)
   g_object_unref (cl);
   BT_TEST_END;
 }
+END_TEST
 
 // test single undo/redo actions
-static void
-test_bt_change_log_single_change_after_redo (BT_TEST_ARGS)
+START_TEST (test_bt_change_log_single_change_after_redo)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -383,10 +382,10 @@ test_bt_change_log_single_change_after_redo (BT_TEST_ARGS)
   g_object_unref (cl);
   BT_TEST_END;
 }
+END_TEST
 
 // test double undo/redo actions
-static void
-test_bt_change_log_two_changes (BT_TEST_ARGS)
+START_TEST (test_bt_change_log_two_changes)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -416,10 +415,10 @@ test_bt_change_log_two_changes (BT_TEST_ARGS)
   g_object_unref (cl);
   BT_TEST_END;
 }
+END_TEST
 
 // test single and then double undo/redo actions
-static void
-test_bt_change_log_single_then_double_change (BT_TEST_ARGS)
+START_TEST (test_bt_change_log_single_then_double_change)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -460,9 +459,9 @@ test_bt_change_log_single_then_double_change (BT_TEST_ARGS)
   g_object_unref (cl);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_change_log_group (BT_TEST_ARGS)
+START_TEST (test_bt_change_log_group)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -477,12 +476,12 @@ test_bt_change_log_group (BT_TEST_ARGS)
 
   // undo & verify
   bt_change_log_undo (cl);
-  fail_unless (tcl->data == NULL, NULL);
+  ck_assert (tcl->data == NULL);
   ck_assert_int_eq (tcl->data_size, 0);
 
   // redo & verify
   bt_change_log_redo (cl);
-  fail_unless (tcl->data != NULL, NULL);
+  ck_assert (tcl->data != NULL);
   ck_assert_int_eq (tcl->data_size, 2);
   ck_assert_int_eq (tcl->data[0], 1);
 
@@ -491,10 +490,10 @@ test_bt_change_log_group (BT_TEST_ARGS)
   g_object_unref (cl);
   BT_TEST_END;
 }
+END_TEST
 
 
-static void
-test_bt_change_log_nested_groups (BT_TEST_ARGS)
+START_TEST (test_bt_change_log_nested_groups)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -512,12 +511,12 @@ test_bt_change_log_nested_groups (BT_TEST_ARGS)
 
   // undo & verify
   bt_change_log_undo (cl);
-  fail_unless (tcl->data == NULL, NULL);
+  ck_assert (tcl->data == NULL);
   ck_assert_int_eq (tcl->data_size, 0);
 
   // redo & verify
   bt_change_log_redo (cl);
-  fail_unless (tcl->data != NULL, NULL);
+  ck_assert (tcl->data != NULL);
   ck_assert_int_eq (tcl->data_size, 2);
   ck_assert_int_eq (tcl->data[0], 1);
   ck_assert_int_eq (tcl->data[1], 1);
@@ -527,9 +526,9 @@ test_bt_change_log_nested_groups (BT_TEST_ARGS)
   g_object_unref (cl);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_change_log_recover (BT_TEST_ARGS)
+START_TEST (test_bt_change_log_recover)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -547,7 +546,7 @@ test_bt_change_log_recover (BT_TEST_ARGS)
   gboolean res = bt_change_log_recover (cl, log_name);
 
   GST_INFO ("-- assert --");
-  fail_unless (res, NULL);
+  ck_assert (res);
 
   GST_INFO ("-- cleanup --");
   flush_main_loop ();
@@ -556,6 +555,7 @@ test_bt_change_log_recover (BT_TEST_ARGS)
   g_object_unref (cl);
   BT_TEST_END;
 }
+END_TEST
 
 TCase *
 bt_change_log_example_case (void)

--- a/tests/ui/edit/e-crash-recover-dialog.c
+++ b/tests/ui/edit/e-crash-recover-dialog.c
@@ -58,8 +58,7 @@ case_teardown (void)
 //-- tests
 
 // create app and then unconditionally destroy window
-static void
-test_bt_crash_recover_dialog_create (BT_TEST_ARGS)
+START_TEST (test_bt_crash_recover_dialog_create)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -79,7 +78,7 @@ test_bt_crash_recover_dialog_create (BT_TEST_ARGS)
   GtkWidget *dialog = GTK_WIDGET (bt_crash_recover_dialog_new (crash_logs));
 
   GST_INFO ("-- assert --");
-  fail_unless (dialog != NULL, NULL);
+  ck_assert (dialog != NULL);
   gtk_widget_show_all (dialog);
   check_make_widget_screenshot (GTK_WIDGET (dialog), NULL);
 
@@ -88,6 +87,7 @@ test_bt_crash_recover_dialog_create (BT_TEST_ARGS)
   g_list_free (crash_logs);
   BT_TEST_END;
 }
+END_TEST
 
 TCase *
 bt_crash_recover_dialog_example_case (void)

--- a/tests/ui/edit/e-edit-application.c
+++ b/tests/ui/edit/e-edit-application.c
@@ -66,8 +66,7 @@ case_teardown (void)
 //-- tests
 
 // create app and then unconditionally destroy window
-static void
-test_bt_edit_application_create (BT_TEST_ARGS)
+START_TEST (test_bt_edit_application_create)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -75,7 +74,7 @@ test_bt_edit_application_create (BT_TEST_ARGS)
   GST_INFO ("-- act --");
 
   GST_INFO ("-- assert --");
-  fail_unless (app != NULL, NULL);
+  ck_assert (app != NULL);
   check_make_widget_screenshot (GTK_WIDGET (main_window), NULL);
   {
     BtCheckWidgetScreenshotRegions regions[] = {
@@ -97,6 +96,7 @@ test_bt_edit_application_create (BT_TEST_ARGS)
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
 static gboolean
 finish_main_loops (gpointer user_data)
@@ -107,8 +107,7 @@ finish_main_loops (gpointer user_data)
 }
 
 // create app and then unconditionally destroy window
-static void
-test_bt_edit_application_run (BT_TEST_ARGS)
+START_TEST (test_bt_edit_application_run)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -127,10 +126,10 @@ test_bt_edit_application_run (BT_TEST_ARGS)
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
 // create a new song
-static void
-test_bt_edit_application_new_song (BT_TEST_ARGS)
+START_TEST (test_bt_edit_application_new_song)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -144,9 +143,9 @@ test_bt_edit_application_new_song (BT_TEST_ARGS)
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_edit_application_new_song_is_saved (BT_TEST_ARGS)
+START_TEST (test_bt_edit_application_new_song_is_saved)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -161,10 +160,10 @@ test_bt_edit_application_new_song_is_saved (BT_TEST_ARGS)
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
 // load a song
-static void
-test_bt_edit_application_load_song (BT_TEST_ARGS)
+START_TEST (test_bt_edit_application_load_song)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -179,9 +178,9 @@ test_bt_edit_application_load_song (BT_TEST_ARGS)
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_edit_application_load_song_is_saved (BT_TEST_ARGS)
+START_TEST (test_bt_edit_application_load_song_is_saved)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -196,10 +195,10 @@ test_bt_edit_application_load_song_is_saved (BT_TEST_ARGS)
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
 // load a song, free it, load another
-static void
-test_bt_edit_application_load_songs (BT_TEST_ARGS)
+START_TEST (test_bt_edit_application_load_songs)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -215,17 +214,17 @@ test_bt_edit_application_load_songs (BT_TEST_ARGS)
 
   GST_INFO ("-- assert --");
   g_object_get (app, "song", &song2, NULL);
-  fail_unless (song2 != NULL, NULL);
-  fail_unless (song2 != song1, NULL);
+  ck_assert (song2 != NULL);
+  ck_assert (song2 != song1);
 
   GST_INFO ("-- cleanup --");
   g_object_unref (song2);
   BT_TEST_END;
 }
+END_TEST
 
 // load a song, free it, load again
-static void
-test_bt_edit_application_num_children (BT_TEST_ARGS)
+START_TEST (test_bt_edit_application_num_children)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -246,16 +245,16 @@ test_bt_edit_application_num_children (BT_TEST_ARGS)
   GST_INFO ("song.elements=%d", GST_BIN_NUMCHILDREN (bin));
 
   GST_INFO ("-- assert --");
-  fail_unless (num == GST_BIN_NUMCHILDREN (bin), NULL);
+  ck_assert (num == GST_BIN_NUMCHILDREN (bin));
 
   GST_INFO ("-- cleanup --");
   gst_object_unref (bin);
   BT_TEST_END;
 }
+END_TEST
 
 // load a song with a view disabled
-static void
-test_bt_edit_application_load_song_with_view_disabled (BT_TEST_ARGS)
+START_TEST (test_bt_edit_application_load_song_with_view_disabled)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -275,10 +274,10 @@ test_bt_edit_application_load_song_with_view_disabled (BT_TEST_ARGS)
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
 // load a song and play it
-static void
-test_bt_edit_application_load_and_play (BT_TEST_ARGS)
+START_TEST (test_bt_edit_application_load_and_play)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -292,7 +291,7 @@ test_bt_edit_application_load_and_play (BT_TEST_ARGS)
   gboolean playing = bt_song_play (song);
 
   GST_INFO ("-- assert --");
-  fail_unless (playing == TRUE, NULL);
+  ck_assert (playing == TRUE);
 
   GST_INFO ("-- cleanup --");
   flush_main_loop ();
@@ -300,10 +299,10 @@ test_bt_edit_application_load_and_play (BT_TEST_ARGS)
   g_object_unref (song);
   BT_TEST_END;
 }
+END_TEST
 
 // load a song, play it and load another song while the former is playing
-static void
-test_bt_edit_application_load_while_playing (BT_TEST_ARGS)
+START_TEST (test_bt_edit_application_load_while_playing)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -325,6 +324,7 @@ test_bt_edit_application_load_while_playing (BT_TEST_ARGS)
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
 TCase *
 bt_edit_application_example_case (void)

--- a/tests/ui/edit/e-interaction-controller-menu.c
+++ b/tests/ui/edit/e-interaction-controller-menu.c
@@ -59,8 +59,7 @@ case_teardown (void)
 
 //-- tests
 
-static void
-test_bt_interaction_controller_menu_create_range_menu (BT_TEST_ARGS)
+START_TEST (test_bt_interaction_controller_menu_create_range_menu)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -71,15 +70,15 @@ test_bt_interaction_controller_menu_create_range_menu (BT_TEST_ARGS)
       NULL);
 
   GST_INFO ("-- assert --");
-  fail_unless (menu != NULL, NULL);
+  ck_assert (menu != NULL);
 
   GST_INFO ("-- cleanup --");
   gtk_widget_destroy (menu);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_interaction_controller_menu_create_trigger_menu (BT_TEST_ARGS)
+START_TEST (test_bt_interaction_controller_menu_create_trigger_menu)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -90,12 +89,13 @@ test_bt_interaction_controller_menu_create_trigger_menu (BT_TEST_ARGS)
       (BT_INTERACTION_CONTROLLER_TRIGGER_MENU, NULL);
 
   GST_INFO ("-- assert --");
-  fail_unless (menu != NULL, NULL);
+  ck_assert (menu != NULL);
 
   GST_INFO ("-- cleanup --");
   gtk_widget_destroy (menu);
   BT_TEST_END;
 }
+END_TEST
 
 TCase *
 bt_interaction_controller_menu_example_case (void)

--- a/tests/ui/edit/e-machine-actions.c
+++ b/tests/ui/edit/e-machine-actions.c
@@ -80,8 +80,7 @@ leave_dialog (gpointer user_data)
 }
 
 // create app and then unconditionally destroy window
-static void
-test_bt_machine_actions_about_dialog (BT_TEST_ARGS)
+START_TEST (test_bt_machine_actions_about_dialog)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -102,7 +101,7 @@ test_bt_machine_actions_about_dialog (BT_TEST_ARGS)
   bt_machine_action_about (machine, main_window);
 
   GST_INFO ("-- assert --");
-  fail_unless (dialog_data.dialog != NULL, NULL);
+  ck_assert (dialog_data.dialog != NULL);
 
   GST_INFO ("-- cleanup --");
   gst_object_unref (machine);
@@ -110,6 +109,7 @@ test_bt_machine_actions_about_dialog (BT_TEST_ARGS)
   g_object_unref (song);
   BT_TEST_END;
 }
+END_TEST
 
 TCase *
 bt_machine_actions_example_case (void)

--- a/tests/ui/edit/e-machine-canvas-item.c
+++ b/tests/ui/edit/e-machine-canvas-item.c
@@ -70,8 +70,7 @@ case_teardown (void)
 
 //-- tests
 
-static void
-test_bt_machine_canvas_item_create (BT_TEST_ARGS)
+START_TEST (test_bt_machine_canvas_item_create)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -86,7 +85,7 @@ test_bt_machine_canvas_item_create (BT_TEST_ARGS)
       bt_machine_canvas_item_new (machines_page, machine, 100.0, 100.0, 1.0);
 
   GST_INFO ("-- assert --");
-  fail_unless (item != NULL, NULL);
+  ck_assert (item != NULL);
 
   GST_INFO ("-- cleanup --");
   flush_main_loop ();
@@ -94,9 +93,9 @@ test_bt_machine_canvas_item_create (BT_TEST_ARGS)
   g_object_unref (machines_page);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_machine_canvas_item_show_analyzer (BT_TEST_ARGS)
+START_TEST (test_bt_machine_canvas_item_show_analyzer)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -115,7 +114,7 @@ test_bt_machine_canvas_item_show_analyzer (BT_TEST_ARGS)
 
   GST_INFO ("-- assert --");
   g_object_get (item, "analysis-dialog", &dialog, NULL);
-  fail_unless (dialog != NULL, NULL);
+  ck_assert (dialog != NULL);
 
   GST_INFO ("-- cleanup --");
   flush_main_loop ();
@@ -124,9 +123,9 @@ test_bt_machine_canvas_item_show_analyzer (BT_TEST_ARGS)
   g_object_unref (machines_page);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_machine_canvas_item_show_preferences (BT_TEST_ARGS)
+START_TEST (test_bt_machine_canvas_item_show_preferences)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -144,7 +143,7 @@ test_bt_machine_canvas_item_show_preferences (BT_TEST_ARGS)
 
   GST_INFO ("-- assert --");
   g_object_get (item, "preferences-dialog", &dialog, NULL);
-  fail_unless (dialog != NULL, NULL);
+  ck_assert (dialog != NULL);
 
   GST_INFO ("-- cleanup --");
   flush_main_loop ();
@@ -153,9 +152,9 @@ test_bt_machine_canvas_item_show_preferences (BT_TEST_ARGS)
   g_object_unref (machines_page);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_machine_canvas_item_show_properties (BT_TEST_ARGS)
+START_TEST (test_bt_machine_canvas_item_show_properties)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -173,7 +172,7 @@ test_bt_machine_canvas_item_show_properties (BT_TEST_ARGS)
 
   GST_INFO ("-- assert --");
   g_object_get (item, "properties-dialog", &dialog, NULL);
-  fail_unless (dialog != NULL, NULL);
+  ck_assert (dialog != NULL);
 
   GST_INFO ("-- cleanup --");
   flush_main_loop ();
@@ -182,6 +181,7 @@ test_bt_machine_canvas_item_show_properties (BT_TEST_ARGS)
   g_object_unref (machines_page);
   BT_TEST_END;
 }
+END_TEST
 
 
 TCase *

--- a/tests/ui/edit/e-machine-list-model.c
+++ b/tests/ui/edit/e-machine-list-model.c
@@ -66,8 +66,7 @@ case_teardown (void)
 
 //-- tests
 
-static void
-test_bt_machine_list_model_create (BT_TEST_ARGS)
+START_TEST (test_bt_machine_list_model_create)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -76,20 +75,23 @@ test_bt_machine_list_model_create (BT_TEST_ARGS)
   BtMachineListModel *model = bt_machine_list_model_new (setup);
 
   GST_INFO ("-- assert --");
-  fail_unless (model != NULL, NULL);
+  ck_assert (model != NULL);
 
   GST_INFO ("-- cleanup --");
   g_object_unref (model);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_machine_list_model_get_machine (BT_TEST_ARGS)
+START_TEST (test_bt_machine_list_model_get_machine)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
   GtkTreeIter iter;
-  BtMachine *machine1 = BT_MACHINE (bt_source_machine_new (song, "gen",
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "gen";
+  BtMachine *machine1 = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-mono-source", 0, NULL));
   BtMachineListModel *model = bt_machine_list_model_new (setup);
   gtk_tree_model_get_iter_first ((GtkTreeModel *) model, &iter);
@@ -98,12 +100,13 @@ test_bt_machine_list_model_get_machine (BT_TEST_ARGS)
   BtMachine *machine2 = bt_machine_list_model_get_object (model, &iter);
 
   GST_INFO ("-- assert --");
-  fail_unless (machine1 == machine2, NULL);
+  ck_assert (machine1 == machine2);
 
   GST_INFO ("-- cleanup --");
   g_object_unref (model);
   BT_TEST_END;
 }
+END_TEST
 
 TCase *
 bt_machine_list_model_example_case (void)

--- a/tests/ui/edit/e-machine-preferences-dialog.c
+++ b/tests/ui/edit/e-machine-preferences-dialog.c
@@ -60,8 +60,7 @@ case_teardown (void)
 //-- tests
 
 // load a song and show machine properties dialog
-static void
-test_bt_machine_preferences_dialog_create (BT_TEST_ARGS)
+START_TEST (test_bt_machine_preferences_dialog_create)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -80,7 +79,7 @@ test_bt_machine_preferences_dialog_create (BT_TEST_ARGS)
   dialog = GTK_WIDGET (bt_machine_preferences_dialog_new (machine));
 
   GST_INFO ("-- assert --");
-  fail_unless (dialog != NULL, NULL);
+  ck_assert (dialog != NULL);
   gtk_widget_show_all (dialog);
   check_make_widget_screenshot (GTK_WIDGET (dialog), NULL);
 
@@ -91,6 +90,7 @@ test_bt_machine_preferences_dialog_create (BT_TEST_ARGS)
   g_object_unref (song);
   BT_TEST_END;
 }
+END_TEST
 
 TCase *
 bt_machine_preferences_dialog_example_case (void)

--- a/tests/ui/edit/e-machine-preset-properties-dialog.c
+++ b/tests/ui/edit/e-machine-preset-properties-dialog.c
@@ -57,8 +57,7 @@ case_teardown (void)
 
 //-- tests
 
-static void
-test_bt_machine_preset_properties_dialog_create (BT_TEST_ARGS)
+START_TEST (test_bt_machine_preset_properties_dialog_create)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -70,7 +69,7 @@ test_bt_machine_preset_properties_dialog_create (BT_TEST_ARGS)
           &comment));
 
   GST_INFO ("-- assert --");
-  fail_unless (dialog != NULL, NULL);
+  ck_assert (dialog != NULL);
   gtk_widget_show_all (dialog);
   check_make_widget_screenshot (GTK_WIDGET (dialog), NULL);
 
@@ -78,6 +77,7 @@ test_bt_machine_preset_properties_dialog_create (BT_TEST_ARGS)
   gtk_widget_destroy (dialog);
   BT_TEST_END;
 }
+END_TEST
 
 TCase *
 bt_machine_preset_properties_dialog_example_case (void)

--- a/tests/ui/edit/e-machine-properties-dialog.c
+++ b/tests/ui/edit/e-machine-properties-dialog.c
@@ -72,8 +72,7 @@ static gchar *element_names[] = {
 };
 static gulong element_voices[] = { 0, 0, 0, 1 };
 
-static void
-test_bt_machine_properties_dialog_create (BT_TEST_ARGS)
+START_TEST (test_bt_machine_properties_dialog_create)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -83,7 +82,10 @@ test_bt_machine_properties_dialog_create (BT_TEST_ARGS)
 
   bt_edit_application_new_song (app);
   g_object_get (app, "song", &song, NULL);
-  machine = BT_MACHINE (bt_source_machine_new (song, "gen", element_names[_i],
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "gen";
+  machine = BT_MACHINE (bt_source_machine_new (&cparams, element_names[_i],
           element_voices[_i], NULL));
   // FIXME: this will still overwrite the file for the two runs with the poly src
   const gchar *name = &element_names[_i][strlen ("buzztrax-test-")];
@@ -92,7 +94,7 @@ test_bt_machine_properties_dialog_create (BT_TEST_ARGS)
   dialog = GTK_WIDGET (bt_machine_properties_dialog_new (machine));
 
   GST_INFO ("-- assert --");
-  fail_unless (dialog != NULL, NULL);
+  ck_assert (dialog != NULL);
   gtk_widget_show_all (dialog);
   check_make_widget_screenshot (GTK_WIDGET (dialog), name);
 
@@ -101,13 +103,13 @@ test_bt_machine_properties_dialog_create (BT_TEST_ARGS)
   g_object_unref (song);
   BT_TEST_END;
 }
+END_TEST
 
 
 // show machine properties dialog while playing to test parameter updates
 static gchar *machine_ids[] = { "beep1", "echo1", "audio_sink" };
 
-static void
-test_bt_machine_properties_dialog_update (BT_TEST_ARGS)
+START_TEST (test_bt_machine_properties_dialog_update)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -141,6 +143,7 @@ test_bt_machine_properties_dialog_update (BT_TEST_ARGS)
   g_object_unref (song);
   BT_TEST_END;
 }
+END_TEST
 
 // TODO(ensonic): test adding/removing voices/wires while dialog is shown
 

--- a/tests/ui/edit/e-machine-rename-dialog.c
+++ b/tests/ui/edit/e-machine-rename-dialog.c
@@ -58,8 +58,7 @@ case_teardown (void)
 //-- tests
 
 // create app and then unconditionally destroy window
-static void
-test_bt_machine_rename_dialog_create (BT_TEST_ARGS)
+START_TEST (test_bt_machine_rename_dialog_create)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -70,15 +69,18 @@ test_bt_machine_rename_dialog_create (BT_TEST_ARGS)
   // create a new song
   bt_edit_application_new_song (app);
   g_object_get (app, "song", &song, NULL);
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "synth";
   machine =
-      BT_MACHINE (bt_source_machine_new (song, "synth",
+      BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-mono-source", 0, NULL));
 
   GST_INFO ("-- act --");
   dialog = GTK_WIDGET (bt_machine_rename_dialog_new (machine));
 
   GST_INFO ("-- assert --");
-  fail_unless (dialog != NULL, NULL);
+  ck_assert (dialog != NULL);
   gtk_widget_show_all (dialog);
   check_make_widget_screenshot (GTK_WIDGET (dialog), NULL);
 
@@ -87,6 +89,7 @@ test_bt_machine_rename_dialog_create (BT_TEST_ARGS)
   g_object_unref (song);
   BT_TEST_END;
 }
+END_TEST
 
 TCase *
 bt_machine_rename_dialog_example_case (void)

--- a/tests/ui/edit/e-main-page-info.c
+++ b/tests/ui/edit/e-main-page-info.c
@@ -71,8 +71,7 @@ case_teardown (void)
 
 //-- tests
 
-static void
-test_bt_main_page_info_focus (BT_TEST_ARGS)
+START_TEST (test_bt_main_page_info_focus)
 {
   BT_TEST_START;
 
@@ -87,6 +86,7 @@ test_bt_main_page_info_focus (BT_TEST_ARGS)
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
 TCase *
 bt_main_page_info_example_case (void)

--- a/tests/ui/edit/e-main-page-machines.c
+++ b/tests/ui/edit/e-main-page-machines.c
@@ -69,8 +69,7 @@ case_teardown (void)
 
 //-- tests
 
-static void
-test_bt_main_page_machines_focus (BT_TEST_ARGS)
+START_TEST (test_bt_main_page_machines_focus)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -84,9 +83,9 @@ test_bt_main_page_machines_focus (BT_TEST_ARGS)
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_main_page_machines_machine_create (BT_TEST_ARGS)
+START_TEST (test_bt_main_page_machines_machine_create)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -101,7 +100,7 @@ test_bt_main_page_machines_machine_create (BT_TEST_ARGS)
   BtMachine *machine = bt_setup_get_machine_by_id (setup, "beep1");
 
   GST_INFO ("-- assert --");
-  fail_unless (machine != NULL, NULL);
+  ck_assert (machine != NULL);
   flush_main_loop ();
 
   GST_INFO ("-- cleanup --");
@@ -110,9 +109,9 @@ test_bt_main_page_machines_machine_create (BT_TEST_ARGS)
   g_object_unref (setup);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_main_page_machines_machine_ref (BT_TEST_ARGS)
+START_TEST (test_bt_main_page_machines_machine_ref)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -148,13 +147,13 @@ test_bt_main_page_machines_machine_ref (BT_TEST_ARGS)
   g_object_unref (setup);
   BT_TEST_END;
 }
+END_TEST
 
 // TODO(ensonic): do the same test for a wire, right now adding a wire is not
 // exposed as public api though
 
 // load a song and remove a machine
-static void
-test_bt_main_page_machines_remove_source_machine (BT_TEST_ARGS)
+START_TEST (test_bt_main_page_machines_remove_source_machine)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -202,10 +201,10 @@ test_bt_main_page_machines_remove_source_machine (BT_TEST_ARGS)
   g_object_unref (song);
   BT_TEST_END;
 }
+END_TEST
 
 // load a song and remove machines
-static void
-test_bt_main_page_machines_remove_processor_machine (BT_TEST_ARGS)
+START_TEST (test_bt_main_page_machines_remove_processor_machine)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -239,9 +238,9 @@ test_bt_main_page_machines_remove_processor_machine (BT_TEST_ARGS)
   g_object_unref (song);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_main_page_machines_remove_wire (BT_TEST_ARGS)
+START_TEST (test_bt_main_page_machines_remove_wire)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -278,11 +277,11 @@ test_bt_main_page_machines_remove_wire (BT_TEST_ARGS)
   g_object_unref (song);
   BT_TEST_END;
 }
+END_TEST
 
 // load a song and remove machines & wires
 // FIXME(ensonic): this test needs work, doing too many things at once
-static void
-test_bt_main_page_machines_edit (BT_TEST_ARGS)
+START_TEST (test_bt_main_page_machines_edit)
 {
   BT_TEST_START;
   BtMainPages *pages;
@@ -350,9 +349,9 @@ test_bt_main_page_machines_edit (BT_TEST_ARGS)
   g_object_unref (song);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_main_page_machines_convert_coordinates (BT_TEST_ARGS)
+START_TEST (test_bt_main_page_machines_convert_coordinates)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -377,6 +376,7 @@ test_bt_main_page_machines_convert_coordinates (BT_TEST_ARGS)
   g_object_unref (machines_page);
   BT_TEST_END;
 }
+END_TEST
 
 TCase *
 bt_main_page_machines_example_case (void)

--- a/tests/ui/edit/e-main-page-patterns.c
+++ b/tests/ui/edit/e-main-page-patterns.c
@@ -76,12 +76,14 @@ move_cursor_to (GtkWidget * w, guint group, guint param, guint digit, guint row)
 
 //-- tests
 
-static void
-test_bt_main_page_patterns_focus (BT_TEST_ARGS)
+START_TEST (test_bt_main_page_patterns_focus)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
-  BtMachine *machine = BT_MACHINE (bt_source_machine_new (song, "gen",
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "gen";
+  BtMachine *machine = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-mono-source", 0L, NULL));
   BtPattern *pattern = bt_pattern_new (song, "pattern-name", 8L, machine);
   BtMainPagePatterns *pattern_page;
@@ -99,14 +101,17 @@ test_bt_main_page_patterns_focus (BT_TEST_ARGS)
   g_object_unref (pattern);
   BT_TEST_END;
 }
+END_TEST
 
 // test entering notes
-static void
-test_bt_main_page_patterns_enter_note (BT_TEST_ARGS)
+START_TEST (test_bt_main_page_patterns_enter_note)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
-  BtMachine *machine = BT_MACHINE (bt_source_machine_new (song, "gen",
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "gen";
+  BtMachine *machine = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-mono-source", 0L, NULL));
   BtPattern *pattern = bt_pattern_new (song, "pattern-name", 8L, machine);
   BtMainPagePatterns *pattern_page;
@@ -124,7 +129,7 @@ test_bt_main_page_patterns_enter_note (BT_TEST_ARGS)
 
   GST_INFO ("-- assert --");
   str = bt_pattern_get_global_event (pattern, 0, 3);
-  fail_unless (str != NULL, NULL);
+  ck_assert (str != NULL);
   str[2] = '0';
   ck_assert_str_eq_and_free (str, "c-0");
 
@@ -133,13 +138,16 @@ test_bt_main_page_patterns_enter_note (BT_TEST_ARGS)
   g_object_unref (pattern);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_main_page_patterns_enter_note_off (BT_TEST_ARGS)
+START_TEST (test_bt_main_page_patterns_enter_note_off)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
-  BtMachine *machine = BT_MACHINE (bt_source_machine_new (song, "gen",
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "gen";
+  BtMachine *machine = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-mono-source", 0L, NULL));
   BtPattern *pattern = bt_pattern_new (song, "pattern-name", 8L, machine);
   BtMainPagePatterns *pattern_page;
@@ -162,14 +170,17 @@ test_bt_main_page_patterns_enter_note_off (BT_TEST_ARGS)
   g_object_unref (pattern);
   BT_TEST_END;
 }
+END_TEST
 
 // test entering notes
-static void
-test_bt_main_page_patterns_clear_note (BT_TEST_ARGS)
+START_TEST (test_bt_main_page_patterns_clear_note)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
-  BtMachine *machine = BT_MACHINE (bt_source_machine_new (song, "gen",
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "gen";
+  BtMachine *machine = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-mono-source", 0L, NULL));
   BtPattern *pattern = bt_pattern_new (song, "pattern-name", 8L, machine);
   BtMainPagePatterns *pattern_page;
@@ -194,14 +205,17 @@ test_bt_main_page_patterns_clear_note (BT_TEST_ARGS)
   g_object_unref (pattern);
   BT_TEST_END;
 }
+END_TEST
 
 // test entering booleans
-static void
-test_bt_main_page_patterns_enter_switch (BT_TEST_ARGS)
+START_TEST (test_bt_main_page_patterns_enter_switch)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
-  BtMachine *machine = BT_MACHINE (bt_source_machine_new (song, "gen",
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "gen";
+  BtMachine *machine = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-mono-source", 0L, NULL));
   BtPattern *pattern = bt_pattern_new (song, "pattern-name", 8L, machine);
   BtMainPagePatterns *pattern_page;
@@ -223,14 +237,17 @@ test_bt_main_page_patterns_enter_switch (BT_TEST_ARGS)
   g_object_unref (pattern);
   BT_TEST_END;
 }
+END_TEST
 
 // test entering sparse enum
-static void
-test_bt_main_page_patterns_enter_sparse_enum (BT_TEST_ARGS)
+START_TEST (test_bt_main_page_patterns_enter_sparse_enum)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
-  BtMachine *machine = BT_MACHINE (bt_source_machine_new (song, "gen",
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "gen";
+  BtMachine *machine = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-mono-source", 0L, NULL));
   BtPattern *pattern = bt_pattern_new (song, "pattern-name", 8L, machine);
   BtMainPagePatterns *pattern_page;
@@ -252,14 +269,17 @@ test_bt_main_page_patterns_enter_sparse_enum (BT_TEST_ARGS)
   g_object_unref (pattern);
   BT_TEST_END;
 }
+END_TEST
 
 // test entering sparse enum
-static void
-test_bt_main_page_patterns_enter_invalid_sparse_enum (BT_TEST_ARGS)
+START_TEST (test_bt_main_page_patterns_enter_invalid_sparse_enum)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
-  BtMachine *machine = BT_MACHINE (bt_source_machine_new (song, "gen",
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "gen";
+  BtMachine *machine = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-mono-source", 0L, NULL));
   BtPattern *pattern = bt_pattern_new (song, "pattern-name", 8L, machine);
   BtMainPagePatterns *pattern_page;
@@ -281,14 +301,17 @@ test_bt_main_page_patterns_enter_invalid_sparse_enum (BT_TEST_ARGS)
   g_object_unref (pattern);
   BT_TEST_END;
 }
+END_TEST
 
 // test entering sparse enum
-static void
-test_bt_main_page_patterns_enter_sparse_enum_in_2_steps (BT_TEST_ARGS)
+START_TEST (test_bt_main_page_patterns_enter_sparse_enum_in_2_steps)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
-  BtMachine *machine = BT_MACHINE (bt_source_machine_new (song, "gen",
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "gen";
+  BtMachine *machine = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-mono-source", 0L, NULL));
   BtPattern *pattern = bt_pattern_new (song, "pattern-name", 8L, machine);
   BtMainPagePatterns *pattern_page;
@@ -312,14 +335,17 @@ test_bt_main_page_patterns_enter_sparse_enum_in_2_steps (BT_TEST_ARGS)
   g_object_unref (pattern);
   BT_TEST_END;
 }
+END_TEST
 
 
-static void
-test_bt_main_page_patterns_pattern_voices (BT_TEST_ARGS)
+START_TEST (test_bt_main_page_patterns_pattern_voices)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
-  BtMachine *machine = BT_MACHINE (bt_source_machine_new (song, "gen",
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "gen";
+  BtMachine *machine = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-poly-source", 1L, NULL));
   BtPattern *pattern = bt_pattern_new (song, "pattern-name", 8L, machine);
   BtMainPagePatterns *pattern_page;
@@ -336,7 +362,7 @@ test_bt_main_page_patterns_pattern_voices (BT_TEST_ARGS)
   g_object_get (pattern, "voices", &voices, NULL);
 
   GST_INFO ("-- assert --");
-  fail_unless (voices == 2, NULL);
+  ck_assert (voices == 2);
   // send two tab keys to ensure the new voice is visible
   check_send_key (pattern_editor, 0, GDK_KEY_Tab, 0);
   check_send_key (pattern_editor, 0, GDK_KEY_Tab, 0);
@@ -347,6 +373,7 @@ test_bt_main_page_patterns_pattern_voices (BT_TEST_ARGS)
   g_object_unref (pattern);
   BT_TEST_END;
 }
+END_TEST
 
 TCase *
 bt_main_page_patterns_example_case (void)

--- a/tests/ui/edit/e-main-page-sequence.c
+++ b/tests/ui/edit/e-main-page-sequence.c
@@ -72,8 +72,7 @@ case_teardown (void)
 
 //-- tests
 
-static void
-test_bt_main_page_sequence_focus (BT_TEST_ARGS)
+START_TEST (test_bt_main_page_sequence_focus)
 {
   BT_TEST_START;
 
@@ -88,10 +87,10 @@ test_bt_main_page_sequence_focus (BT_TEST_ARGS)
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
 // activate tracks
-static void
-test_bt_main_page_sequence_active_machine (BT_TEST_ARGS)
+START_TEST (test_bt_main_page_sequence_active_machine)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -99,10 +98,14 @@ test_bt_main_page_sequence_active_machine (BT_TEST_ARGS)
   // (main-page-sequence is not listening for "track-added" signal).
   // When adding a src, a track is added automatically and this updates the
   // view though.
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "fx";
   bt_sequence_add_track (sequence,
-      BT_MACHINE (bt_processor_machine_new (song, "fx", "volume", 0L, NULL)),
+      BT_MACHINE (bt_processor_machine_new (&cparams, "volume", 0L, NULL)),
       -1);
-  bt_source_machine_new (song, "gen", "simsyn", 0L, NULL);
+  cparams.id = "gen";
+  bt_source_machine_new (&cparams, "simsyn", 0L, NULL);
   BtMainPageSequence *sequence_page;
   GtkWidget *sequence_view;
 
@@ -135,14 +138,17 @@ test_bt_main_page_sequence_active_machine (BT_TEST_ARGS)
   g_object_unref (sequence_page);
   BT_TEST_END;
 }
+END_TEST
 
 // activate tracks
-static void
-test_bt_main_page_sequence_enter_pattern (BT_TEST_ARGS)
+START_TEST (test_bt_main_page_sequence_enter_pattern)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
-  BtMachine *machine = BT_MACHINE (bt_source_machine_new (song, "gen",
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "gen";
+  BtMachine *machine = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-mono-source", 0L, NULL));
   BtPattern *pattern1 = bt_pattern_new (song, "pattern-name", 8L, machine);
   BtMainPageSequence *sequence_page;
@@ -164,6 +170,7 @@ test_bt_main_page_sequence_enter_pattern (BT_TEST_ARGS)
   g_object_unref (pattern1);
   BT_TEST_END;
 }
+END_TEST
 
 TCase *
 bt_main_page_sequence_example_case (void)

--- a/tests/ui/edit/e-main-pages.c
+++ b/tests/ui/edit/e-main-pages.c
@@ -91,8 +91,7 @@ case_teardown (void)
 //-- tests
 
 // view all tabs
-static void
-test_bt_main_pages_view_all_tabs (BT_TEST_ARGS)
+START_TEST (test_bt_main_pages_view_all_tabs)
 {
   BT_TEST_START;
   BtMainPagePatterns *pattern_page;
@@ -121,10 +120,10 @@ test_bt_main_pages_view_all_tabs (BT_TEST_ARGS)
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
 // view all tabs
-static void
-test_bt_main_pages_view_all_tabs_playing (BT_TEST_ARGS)
+START_TEST (test_bt_main_pages_view_all_tabs_playing)
 {
   BT_TEST_START;
   BtMainPagePatterns *pattern_page;
@@ -152,6 +151,7 @@ test_bt_main_pages_view_all_tabs_playing (BT_TEST_ARGS)
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
 TCase *
 bt_main_pages_example_case (void)

--- a/tests/ui/edit/e-main-window.c
+++ b/tests/ui/edit/e-main-window.c
@@ -95,8 +95,7 @@ leave_dialog (gpointer user_data)
 }
 
 // test message dialog
-static void
-test_bt_main_window_message (BT_TEST_ARGS)
+START_TEST (test_bt_main_window_message)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -107,15 +106,15 @@ test_bt_main_window_message (BT_TEST_ARGS)
   bt_dialog_message (main_window, "title", "headline", "message");
 
   GST_INFO ("-- assert --");
-  fail_unless (dialog_data.dialog != NULL, NULL);
+  ck_assert (dialog_data.dialog != NULL);
 
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
 // test question dialog
-static void
-test_bt_main_window_question (BT_TEST_ARGS)
+START_TEST (test_bt_main_window_question)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -127,16 +126,16 @@ test_bt_main_window_question (BT_TEST_ARGS)
       bt_dialog_question (main_window, "title", "headline", "message");
 
   GST_INFO ("-- assert --");
-  fail_unless (res == TRUE, NULL);
-  fail_unless (dialog_data.dialog != NULL, NULL);
+  ck_assert (res == TRUE);
+  ck_assert (dialog_data.dialog != NULL);
 
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
 // test open a song, but cancel
-static void
-test_bt_main_window_open_song (BT_TEST_ARGS)
+START_TEST (test_bt_main_window_open_song)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -147,15 +146,15 @@ test_bt_main_window_open_song (BT_TEST_ARGS)
   bt_main_window_open_song (main_window);
 
   GST_INFO ("-- assert --");
-  fail_unless (dialog_data.dialog != NULL, NULL);
+  ck_assert (dialog_data.dialog != NULL);
 
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
 // test open a song, but cancel
-static void
-test_bt_main_window_save_song_as (BT_TEST_ARGS)
+START_TEST (test_bt_main_window_save_song_as)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -167,14 +166,14 @@ test_bt_main_window_save_song_as (BT_TEST_ARGS)
   bt_main_window_save_song_as (main_window);
 
   GST_INFO ("-- assert --");
-  fail_unless (dialog_data.dialog != NULL, NULL);
+  ck_assert (dialog_data.dialog != NULL);
 
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_main_window_check_unsaved (BT_TEST_ARGS)
+START_TEST (test_bt_main_window_check_unsaved)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -185,15 +184,15 @@ test_bt_main_window_check_unsaved (BT_TEST_ARGS)
   gboolean res = bt_main_window_check_unsaved_song (main_window, "X", "X");
 
   GST_INFO ("-- assert --");
-  fail_unless (res == TRUE, NULL);
+  ck_assert (res == TRUE);
 
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
 // ensure window title is correct without a song title explicitly set
-static void
-test_bt_main_window_song_title_untitled (BT_TEST_ARGS)
+START_TEST (test_bt_main_window_song_title_untitled)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -216,10 +215,10 @@ test_bt_main_window_song_title_untitled (BT_TEST_ARGS)
   
   BT_TEST_END;
 }
+END_TEST
 
 // ensure window title is correct with a song title explicitly set
-static void
-test_bt_main_window_song_title_titled (BT_TEST_ARGS)
+START_TEST (test_bt_main_window_song_title_titled)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -250,10 +249,10 @@ test_bt_main_window_song_title_titled (BT_TEST_ARGS)
   
   BT_TEST_END;
 }
+END_TEST
 
 // ensure that the filename chosen for an untitled song is correct
-static void
-test_bt_main_window_song_title_save (BT_TEST_ARGS)
+START_TEST (test_bt_main_window_song_title_save)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -276,6 +275,7 @@ test_bt_main_window_song_title_save (BT_TEST_ARGS)
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
 TCase *
 bt_main_window_example_case (void)

--- a/tests/ui/edit/e-missing-framework-elements-dialog.c
+++ b/tests/ui/edit/e-missing-framework-elements-dialog.c
@@ -58,8 +58,7 @@ case_teardown (void)
 //-- tests
 
 // create app and then unconditionally destroy window
-static void
-test_bt_missing_framework_elements_dialog_create_empty (BT_TEST_ARGS)
+START_TEST (test_bt_missing_framework_elements_dialog_create_empty)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -69,16 +68,16 @@ test_bt_missing_framework_elements_dialog_create_empty (BT_TEST_ARGS)
       GTK_WIDGET (bt_missing_framework_elements_dialog_new (NULL, NULL));
 
   GST_INFO ("-- assert --");
-  fail_unless (dialog != NULL, NULL);
+  ck_assert (dialog != NULL);
   gtk_widget_show_all (dialog);
 
   GST_INFO ("-- cleanup --");
   gtk_widget_destroy (dialog);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_missing_framework_elements_dialog_create (BT_TEST_ARGS)
+START_TEST (test_bt_missing_framework_elements_dialog_create)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -95,7 +94,7 @@ test_bt_missing_framework_elements_dialog_create (BT_TEST_ARGS)
           missing_elements));
 
   GST_INFO ("-- assert --");
-  fail_unless (dialog != NULL, NULL);
+  ck_assert (dialog != NULL);
   gtk_widget_show_all (dialog);
   check_make_widget_screenshot (GTK_WIDGET (dialog), NULL);
 
@@ -103,6 +102,7 @@ test_bt_missing_framework_elements_dialog_create (BT_TEST_ARGS)
   gtk_widget_destroy (dialog);
   BT_TEST_END;
 }
+END_TEST
 
 TCase *
 bt_missing_framework_elements_dialog_example_case (void)

--- a/tests/ui/edit/e-missing-song-elements-dialog.c
+++ b/tests/ui/edit/e-missing-song-elements-dialog.c
@@ -58,8 +58,7 @@ case_teardown (void)
 //-- tests
 
 // create app and then unconditionally destroy window
-static void
-test_bt_missing_song_elements_dialog_create_empty (BT_TEST_ARGS)
+START_TEST (test_bt_missing_song_elements_dialog_create_empty)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -69,16 +68,16 @@ test_bt_missing_song_elements_dialog_create_empty (BT_TEST_ARGS)
       GTK_WIDGET (bt_missing_song_elements_dialog_new (NULL, NULL));
 
   GST_INFO ("-- assert --");
-  fail_unless (dialog != NULL, NULL);
+  ck_assert (dialog != NULL);
   gtk_widget_show_all (dialog);
 
   GST_INFO ("-- cleanup --");
   gtk_widget_destroy (dialog);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_missing_song_elements_dialog_create (BT_TEST_ARGS)
+START_TEST (test_bt_missing_song_elements_dialog_create)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -94,7 +93,7 @@ test_bt_missing_song_elements_dialog_create (BT_TEST_ARGS)
           missing_waves));
 
   GST_INFO ("-- assert --");
-  fail_unless (dialog != NULL, NULL);
+  ck_assert (dialog != NULL);
   gtk_widget_show_all (dialog);
   check_make_widget_screenshot (GTK_WIDGET (dialog), NULL);
 
@@ -102,6 +101,7 @@ test_bt_missing_song_elements_dialog_create (BT_TEST_ARGS)
   gtk_widget_destroy (dialog);
   BT_TEST_END;
 }
+END_TEST
 
 TCase *
 bt_missing_song_elements_dialog_example_case (void)

--- a/tests/ui/edit/e-object-list-model.c
+++ b/tests/ui/edit/e-object-list-model.c
@@ -57,8 +57,7 @@ case_teardown (void)
 
 //-- tests
 
-static void
-test_bt_object_list_model_create (BT_TEST_ARGS)
+START_TEST (test_bt_object_list_model_create)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -68,15 +67,15 @@ test_bt_object_list_model_create (BT_TEST_ARGS)
       "label");
 
   GST_INFO ("-- assert --");
-  fail_unless (model != NULL, NULL);
+  ck_assert (model != NULL);
 
   GST_INFO ("-- cleanup --");
   g_object_unref (g_object_ref_sink (model));
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_object_list_model_add_entry (BT_TEST_ARGS)
+START_TEST (test_bt_object_list_model_add_entry)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -91,13 +90,14 @@ test_bt_object_list_model_add_entry (BT_TEST_ARGS)
   GtkWidget *l2 = (GtkWidget *) bt_object_list_model_get_object (model, &iter);
 
   GST_INFO ("-- assert --");
-  fail_unless (l1 == l2, NULL);
+  ck_assert (l1 == l2);
 
   GST_INFO ("-- cleanup --");
   g_object_unref (l1);
   g_object_unref (g_object_ref_sink (model));
   BT_TEST_END;
 }
+END_TEST
 
 TCase *
 bt_object_list_model_example_case (void)

--- a/tests/ui/edit/e-pattern-list-model.c
+++ b/tests/ui/edit/e-pattern-list-model.c
@@ -68,12 +68,14 @@ case_teardown (void)
 
 //-- tests
 
-static void
-test_bt_pattern_list_model_create (BT_TEST_ARGS)
+START_TEST (test_bt_pattern_list_model_create)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
-  BtMachine *machine = BT_MACHINE (bt_source_machine_new (song, "gen",
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "gen";
+  BtMachine *machine = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-mono-source", 0, NULL));
 
   GST_INFO ("-- act --");
@@ -81,15 +83,15 @@ test_bt_pattern_list_model_create (BT_TEST_ARGS)
       TRUE);
 
   GST_INFO ("-- assert --");
-  fail_unless (model != NULL, NULL);
+  ck_assert (model != NULL);
 
   GST_INFO ("-- cleanup --");
   g_object_unref (model);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_pattern_list_model_get_pattern (BT_TEST_ARGS)
+START_TEST (test_bt_pattern_list_model_get_pattern)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -104,7 +106,7 @@ test_bt_pattern_list_model_get_pattern (BT_TEST_ARGS)
   BtPattern *pattern2 = bt_pattern_list_model_get_object (model, &iter);
 
   GST_INFO ("-- assert --");
-  fail_unless (pattern1 == pattern2, NULL);
+  ck_assert (pattern1 == pattern2);
 
   GST_INFO ("-- cleanup --");
   g_object_unref (model);
@@ -112,6 +114,7 @@ test_bt_pattern_list_model_get_pattern (BT_TEST_ARGS)
   g_object_unref (machine);
   BT_TEST_END;
 }
+END_TEST
 
 TCase *
 bt_pattern_list_model_example_case (void)

--- a/tests/ui/edit/e-pattern-properties-dialog.c
+++ b/tests/ui/edit/e-pattern-properties-dialog.c
@@ -57,8 +57,7 @@ case_teardown (void)
 
 //-- tests
 
-static void
-test_bt_pattern_properties_dialog_create (BT_TEST_ARGS)
+START_TEST (test_bt_pattern_properties_dialog_create)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -67,7 +66,10 @@ test_bt_pattern_properties_dialog_create (BT_TEST_ARGS)
   // create a new song
   bt_edit_application_new_song (app);
   g_object_get (app, "song", &song, NULL);
-  BtMachine *machine = BT_MACHINE (bt_source_machine_new (song, "gen",
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "gen";
+  BtMachine *machine = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-mono-source", 0, NULL));
   BtPattern *pattern = bt_pattern_new (song, "test", /*length= */ 16, machine);
 
@@ -75,7 +77,7 @@ test_bt_pattern_properties_dialog_create (BT_TEST_ARGS)
   GtkWidget *dialog = GTK_WIDGET (bt_pattern_properties_dialog_new (pattern));
 
   GST_INFO ("-- assert --");
-  fail_unless (dialog != NULL, NULL);
+  ck_assert (dialog != NULL);
   gtk_widget_show_all (dialog);
   check_make_widget_screenshot (GTK_WIDGET (dialog), NULL);
 
@@ -85,6 +87,7 @@ test_bt_pattern_properties_dialog_create (BT_TEST_ARGS)
   g_object_unref (song);
   BT_TEST_END;
 }
+END_TEST
 
 TCase *
 bt_pattern_properties_dialog_example_case (void)

--- a/tests/ui/edit/e-preset-list-model.c
+++ b/tests/ui/edit/e-preset-list-model.c
@@ -68,8 +68,7 @@ case_teardown (void)
 
 //-- tests
 
-static void
-test_bt_preset_list_model_create (BT_TEST_ARGS)
+START_TEST (test_bt_preset_list_model_create)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -80,13 +79,14 @@ test_bt_preset_list_model_create (BT_TEST_ARGS)
   BtPresetListModel *model = bt_preset_list_model_new (machine);
 
   GST_INFO ("-- assert --");
-  fail_unless (model != NULL, NULL);
+  ck_assert (model != NULL);
 
   GST_INFO ("-- cleanup --");
   g_object_unref (model);
   gst_object_unref (machine);
   BT_TEST_END;
 }
+END_TEST
 
 TCase *
 bt_preset_list_model_example_case (void)

--- a/tests/ui/edit/e-render-dialog.c
+++ b/tests/ui/edit/e-render-dialog.c
@@ -57,8 +57,7 @@ case_teardown (void)
 
 //-- tests
 
-static void
-test_bt_render_dialog_create (BT_TEST_ARGS)
+START_TEST (test_bt_render_dialog_create)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -70,7 +69,7 @@ test_bt_render_dialog_create (BT_TEST_ARGS)
   dialog = GTK_WIDGET (bt_render_dialog_new ());
 
   GST_INFO ("-- assert --");
-  fail_unless (dialog != NULL, NULL);
+  ck_assert (dialog != NULL);
   gtk_widget_show_all (dialog);
   check_make_widget_screenshot (GTK_WIDGET (dialog), NULL);
 
@@ -78,6 +77,7 @@ test_bt_render_dialog_create (BT_TEST_ARGS)
   gtk_widget_destroy (dialog);
   BT_TEST_END;
 }
+END_TEST
 
 TCase *
 bt_render_dialog_example_case (void)

--- a/tests/ui/edit/e-sequence-grid-model.c
+++ b/tests/ui/edit/e-sequence-grid-model.c
@@ -68,8 +68,7 @@ case_teardown (void)
 
 //-- tests
 
-static void
-test_bt_sequence_grid_model_create (BT_TEST_ARGS)
+START_TEST (test_bt_sequence_grid_model_create)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -79,12 +78,13 @@ test_bt_sequence_grid_model_create (BT_TEST_ARGS)
       16);
 
   GST_INFO ("-- assert --");
-  fail_unless (model != NULL, NULL);
+  ck_assert (model != NULL);
 
   GST_INFO ("-- cleanup --");
   g_object_unref (model);
   BT_TEST_END;
 }
+END_TEST
 
 TCase *
 bt_sequence_grid_model_example_case (void)

--- a/tests/ui/edit/e-settings-dialog.c
+++ b/tests/ui/edit/e-settings-dialog.c
@@ -57,8 +57,7 @@ case_teardown (void)
 
 //-- tests
 
-static void
-test_bt_settings_dialog_create (BT_TEST_ARGS)
+START_TEST (test_bt_settings_dialog_create)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -69,7 +68,7 @@ test_bt_settings_dialog_create (BT_TEST_ARGS)
   GtkWidget *dialog = GTK_WIDGET (bt_settings_dialog_new ());
 
   GST_INFO ("-- assert --");
-  fail_unless (dialog != NULL, NULL);
+  ck_assert (dialog != NULL);
   g_object_set (G_OBJECT (dialog), "page", _i, NULL);
   gtk_widget_show_all (dialog);
   check_make_widget_screenshot (dialog, enum_value->value_nick);
@@ -79,6 +78,7 @@ test_bt_settings_dialog_create (BT_TEST_ARGS)
   g_type_class_unref (enum_class);
   BT_TEST_END;
 }
+END_TEST
 
 TCase *
 bt_settings_dialog_example_case (void)

--- a/tests/ui/edit/e-signal-analysis-dialog.c
+++ b/tests/ui/edit/e-signal-analysis-dialog.c
@@ -60,8 +60,7 @@ case_teardown (void)
 //-- tests
 
 // load a song and show machine properties dialog
-static void
-test_bt_signal_analysis_dialog_create (BT_TEST_ARGS)
+START_TEST (test_bt_signal_analysis_dialog_create)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -95,6 +94,7 @@ test_bt_signal_analysis_dialog_create (BT_TEST_ARGS)
   g_object_unref (song);
   BT_TEST_END;
 }
+END_TEST
 
 TCase *
 bt_signal_analysis_dialog_example_case (void)

--- a/tests/ui/edit/e-tip-dialog.c
+++ b/tests/ui/edit/e-tip-dialog.c
@@ -58,8 +58,7 @@ case_teardown (void)
 //-- tests
 
 // create app and then unconditionally destroy window
-static void
-test_bt_tip_dialog_create (BT_TEST_ARGS)
+START_TEST (test_bt_tip_dialog_create)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -68,7 +67,7 @@ test_bt_tip_dialog_create (BT_TEST_ARGS)
   GtkWidget *dialog = GTK_WIDGET (bt_tip_dialog_new ());
 
   GST_INFO ("-- assert --");
-  fail_unless (dialog != NULL, NULL);
+  ck_assert (dialog != NULL);
   gtk_widget_show_all (dialog);
   check_make_widget_screenshot (GTK_WIDGET (dialog), NULL);
 
@@ -76,6 +75,7 @@ test_bt_tip_dialog_create (BT_TEST_ARGS)
   gtk_widget_destroy (dialog);
   BT_TEST_END;
 }
+END_TEST
 
 TCase *
 bt_tip_dialog_example_case (void)

--- a/tests/ui/edit/e-tools.c
+++ b/tests/ui/edit/e-tools.c
@@ -47,8 +47,7 @@ case_teardown (void)
 
 //-- tests
 
-static void
-test_bt_strjoin_list_with_empty_list (BT_TEST_ARGS)
+START_TEST (test_bt_strjoin_list_with_empty_list)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -57,14 +56,14 @@ test_bt_strjoin_list_with_empty_list (BT_TEST_ARGS)
   gchar *res = bt_strjoin_list (NULL);
 
   GST_INFO ("-- assert --");
-  fail_unless (res == NULL, NULL);
+  ck_assert (res == NULL);
 
   GST_INFO ("-- cleanup --");
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_strjoin_list_with_single_value_list (BT_TEST_ARGS)
+START_TEST (test_bt_strjoin_list_with_single_value_list)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -74,17 +73,17 @@ test_bt_strjoin_list_with_single_value_list (BT_TEST_ARGS)
   gchar *res = bt_strjoin_list (list);
 
   GST_INFO ("-- assert --");
-  fail_unless (res != NULL, NULL);
-  fail_unless (strcmp ("first", res) == 0, NULL);
+  ck_assert (res != NULL);
+  ck_assert (strcmp ("first", res) == 0);
 
   GST_INFO ("-- cleanup --");
   g_free (res);
   g_list_free (list);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_strjoin_list_with_two_value_list (BT_TEST_ARGS)
+START_TEST (test_bt_strjoin_list_with_two_value_list)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -95,14 +94,15 @@ test_bt_strjoin_list_with_two_value_list (BT_TEST_ARGS)
   gchar *res = bt_strjoin_list (list);
 
   GST_INFO ("-- assert --");
-  fail_unless (res != NULL, NULL);
-  fail_unless (strcmp ("first\nsecond", res) == 0, NULL);
+  ck_assert (res != NULL);
+  ck_assert (strcmp ("first\nsecond", res) == 0);
 
   GST_INFO ("-- cleanup --");
   g_free (res);
   g_list_free (list);
   BT_TEST_END;
 }
+END_TEST
 
 
 TCase *

--- a/tests/ui/edit/e-ui-resources.c
+++ b/tests/ui/edit/e-ui-resources.c
@@ -59,8 +59,7 @@ case_teardown (void)
 
 //-- tests
 
-static void
-test_bt_ui_resources_create (BT_TEST_ARGS)
+START_TEST (test_bt_ui_resources_create)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -69,15 +68,15 @@ test_bt_ui_resources_create (BT_TEST_ARGS)
   BtUIResources *res = bt_ui_resources_new ();
 
   GST_INFO ("-- assert --");
-  fail_unless (res != NULL, NULL);
+  ck_assert (res != NULL);
 
   GST_INFO ("-- cleanup --");
   g_object_unref (res);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_ui_resources_singleton (BT_TEST_ARGS)
+START_TEST (test_bt_ui_resources_singleton)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -87,13 +86,14 @@ test_bt_ui_resources_singleton (BT_TEST_ARGS)
   BtUIResources *res2 = bt_ui_resources_new ();
 
   GST_INFO ("-- assert --");
-  fail_unless (res1 == res2, NULL);
+  ck_assert (res1 == res2);
 
   GST_INFO ("-- cleanup --");
   g_object_unref (res2);
   g_object_unref (res1);
   BT_TEST_END;
 }
+END_TEST
 
 TCase *
 bt_ui_resources_example_case (void)

--- a/tests/ui/edit/e-wave-list-model.c
+++ b/tests/ui/edit/e-wave-list-model.c
@@ -57,8 +57,7 @@ case_teardown (void)
 
 //-- tests
 
-static void
-test_bt_wave_list_model_create (BT_TEST_ARGS)
+START_TEST (test_bt_wave_list_model_create)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -73,7 +72,7 @@ test_bt_wave_list_model_create (BT_TEST_ARGS)
   BtWaveListModel *model = bt_wave_list_model_new (wavetable);
 
   GST_INFO ("-- assert --");
-  fail_unless (model != NULL, NULL);
+  ck_assert (model != NULL);
 
   GST_INFO ("-- cleanup --");
   g_object_unref (model);
@@ -81,9 +80,9 @@ test_bt_wave_list_model_create (BT_TEST_ARGS)
   g_object_unref (song);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_wave_list_model_get_null_wave (BT_TEST_ARGS)
+START_TEST (test_bt_wave_list_model_get_null_wave)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -101,7 +100,7 @@ test_bt_wave_list_model_get_null_wave (BT_TEST_ARGS)
   BtWave *wave = bt_wave_list_model_get_object (model, &iter);
 
   GST_INFO ("-- assert --");
-  fail_unless (wave == NULL, NULL);
+  ck_assert (wave == NULL);
 
   GST_INFO ("-- cleanup --");
   g_object_unref (model);
@@ -109,6 +108,7 @@ test_bt_wave_list_model_get_null_wave (BT_TEST_ARGS)
   g_object_unref (song);
   BT_TEST_END;
 }
+END_TEST
 
 TCase *
 bt_wave_list_model_example_case (void)

--- a/tests/ui/edit/e-wavelevel-list-model.c
+++ b/tests/ui/edit/e-wavelevel-list-model.c
@@ -63,8 +63,7 @@ case_teardown (void)
 
 //-- tests
 
-static void
-test_bt_wavelevel_list_model_create_null (BT_TEST_ARGS)
+START_TEST (test_bt_wavelevel_list_model_create_null)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -75,15 +74,15 @@ test_bt_wavelevel_list_model_create_null (BT_TEST_ARGS)
   BtWavelevelListModel *model = bt_wavelevel_list_model_new (NULL);
 
   GST_INFO ("-- assert --");
-  fail_unless (model != NULL, NULL);
+  ck_assert (model != NULL);
 
   GST_INFO ("-- cleanup --");
   g_object_unref (model);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_wavelevel_list_model_create (BT_TEST_ARGS)
+START_TEST (test_bt_wavelevel_list_model_create)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -98,7 +97,7 @@ test_bt_wavelevel_list_model_create (BT_TEST_ARGS)
   BtWavelevelListModel *model = bt_wavelevel_list_model_new (wave);
 
   GST_INFO ("-- assert --");
-  fail_unless (model != NULL, NULL);
+  ck_assert (model != NULL);
 
   GST_INFO ("-- cleanup --");
   g_object_unref (model);
@@ -106,10 +105,10 @@ test_bt_wavelevel_list_model_create (BT_TEST_ARGS)
   g_object_unref (song);
   BT_TEST_END;
 }
+END_TEST
 
 // load a wave and check the wavelevel
-static void
-test_bt_wavelevel_list_model_get_wavelevel (BT_TEST_ARGS)
+START_TEST (test_bt_wavelevel_list_model_get_wavelevel)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -127,7 +126,7 @@ test_bt_wavelevel_list_model_get_wavelevel (BT_TEST_ARGS)
   BtWavelevel *wavelevel = bt_wavelevel_list_model_get_object (model, &iter);
 
   GST_INFO ("-- assert --");
-  fail_unless (wavelevel != NULL, NULL);
+  ck_assert (wavelevel != NULL);
 
   GST_INFO ("-- cleanup --");
   g_object_unref (wavelevel);
@@ -135,6 +134,7 @@ test_bt_wavelevel_list_model_get_wavelevel (BT_TEST_ARGS)
   g_object_unref (song);
   BT_TEST_END;
 }
+END_TEST
 
 TCase *
 bt_wavelevel_list_model_example_case (void)

--- a/tests/ui/edit/e-wire-canvas-item.c
+++ b/tests/ui/edit/e-wire-canvas-item.c
@@ -70,8 +70,7 @@ case_teardown (void)
 
 //-- tests
 
-static void
-test_bt_wire_canvas_item_create (BT_TEST_ARGS)
+START_TEST (test_bt_wire_canvas_item_create)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -92,7 +91,7 @@ test_bt_wire_canvas_item_create (BT_TEST_ARGS)
       bt_wire_canvas_item_new (machines_page, wire, item1, item2);
 
   GST_INFO ("-- assert --");
-  fail_unless (item != NULL, NULL);
+  ck_assert (item != NULL);
 
   GST_INFO ("-- cleanup --");
   flush_main_loop ();
@@ -101,9 +100,9 @@ test_bt_wire_canvas_item_create (BT_TEST_ARGS)
   g_object_unref (machines_page);
   BT_TEST_END;
 }
+END_TEST
 
-static void
-test_bt_wire_canvas_item_show_analyzer (BT_TEST_ARGS)
+START_TEST (test_bt_wire_canvas_item_show_analyzer)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -127,7 +126,7 @@ test_bt_wire_canvas_item_show_analyzer (BT_TEST_ARGS)
 
   GST_INFO ("-- assert --");
   g_object_get (item, "analysis-dialog", &dialog, NULL);
-  fail_unless (dialog != NULL, NULL);
+  ck_assert (dialog != NULL);
 
   GST_INFO ("-- cleanup --");
   flush_main_loop ();
@@ -137,6 +136,7 @@ test_bt_wire_canvas_item_show_analyzer (BT_TEST_ARGS)
   g_object_unref (machines_page);
   BT_TEST_END;
 }
+END_TEST
 
 TCase *
 bt_wire_canvas_item_example_case (void)

--- a/tests/ui/edit/t-change-log.c
+++ b/tests/ui/edit/t-change-log.c
@@ -59,8 +59,7 @@ case_teardown (void)
 
 //-- tests
 
-static void
-test_bt_change_log_recover_while_missing_machine (BT_TEST_ARGS)
+START_TEST (test_bt_change_log_recover_while_missing_machine)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -78,7 +77,7 @@ test_bt_change_log_recover_while_missing_machine (BT_TEST_ARGS)
   gboolean res = bt_change_log_recover (cl, log_name);
 
   GST_INFO ("-- assert --");
-  fail_if (res, NULL);
+  ck_assert (!(res));
 
   GST_INFO ("-- cleanup --");
   flush_main_loop ();
@@ -86,6 +85,7 @@ test_bt_change_log_recover_while_missing_machine (BT_TEST_ARGS)
   g_object_unref (cl);
   BT_TEST_END;
 }
+END_TEST
 
 TCase *
 bt_change_log_test_case (void)

--- a/tests/ui/edit/t-main-page-patterns.c
+++ b/tests/ui/edit/t-main-page-patterns.c
@@ -106,7 +106,6 @@ START_TEST (test_bt_main_page_patterns_key_press_in_empty_pattern)
   BT_TEST_END;
 }
 END_TEST
-END_TEST
 
 // show pattern page with empty pattern and emit mouse clicks
 START_TEST (test_bt_main_page_patterns_mouse_click_in_empty_pattern)
@@ -136,7 +135,6 @@ START_TEST (test_bt_main_page_patterns_mouse_click_in_empty_pattern)
   g_object_unref (pattern_page);
   BT_TEST_END;
 }
-END_TEST
 END_TEST
 
 // test entering non note key
@@ -169,7 +167,6 @@ START_TEST (test_bt_main_page_patterns_non_note_key_press)
   g_object_unref (pattern);
   BT_TEST_END;
 }
-END_TEST
 END_TEST
 
 // test that cursor pos stays unchanged on invalid key presses
@@ -204,7 +201,6 @@ START_TEST (test_bt_main_page_patterns_cursor_pos_on_non_note_key)
   g_object_unref (pattern);
   BT_TEST_END;
 }
-END_TEST
 END_TEST
 
 

--- a/tests/ui/edit/t-main-page-patterns.c
+++ b/tests/ui/edit/t-main-page-patterns.c
@@ -77,8 +77,7 @@ move_cursor_to (GtkWidget * w, guint group, guint param, guint digit, guint row)
 //-- tests
 
 // show pattern page with empty pattern and emit key-presses
-static void
-test_bt_main_page_patterns_key_press_in_empty_pattern (BT_TEST_ARGS)
+START_TEST (test_bt_main_page_patterns_key_press_in_empty_pattern)
 {
   BT_TEST_START;
   BtMainPagePatterns *pattern_page;
@@ -86,8 +85,11 @@ test_bt_main_page_patterns_key_press_in_empty_pattern (BT_TEST_ARGS)
   GtkWidget *pattern_editor;
 
   GST_INFO ("-- arrange --");
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "gen";
   machine =
-      BT_MACHINE (bt_source_machine_new (song, "gen", "fakesrc", 0, NULL));
+      BT_MACHINE (bt_source_machine_new (&cparams, "fakesrc", 0, NULL));
   g_object_get (G_OBJECT (pages), "patterns-page", &pattern_page, NULL);
   bt_main_page_patterns_show_machine (pattern_page, machine);
   pattern_editor = gtk_window_get_focus ((GtkWindow *) main_window);
@@ -103,10 +105,11 @@ test_bt_main_page_patterns_key_press_in_empty_pattern (BT_TEST_ARGS)
   g_object_unref (pattern_page);
   BT_TEST_END;
 }
+END_TEST
+END_TEST
 
 // show pattern page with empty pattern and emit mouse clicks
-static void
-test_bt_main_page_patterns_mouse_click_in_empty_pattern (BT_TEST_ARGS)
+START_TEST (test_bt_main_page_patterns_mouse_click_in_empty_pattern)
 {
   BT_TEST_START;
   BtMainPagePatterns *pattern_page;
@@ -114,8 +117,11 @@ test_bt_main_page_patterns_mouse_click_in_empty_pattern (BT_TEST_ARGS)
   GtkWidget *pattern_editor;
 
   GST_INFO ("-- arrange --");
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "gen";
   machine =
-      BT_MACHINE (bt_source_machine_new (song, "gen", "fakesrc", 0, NULL));
+      BT_MACHINE (bt_source_machine_new (&cparams, "fakesrc", 0, NULL));
   g_object_get (G_OBJECT (pages), "patterns-page", &pattern_page, NULL);
   bt_main_page_patterns_show_machine (pattern_page, machine);
   pattern_editor = gtk_window_get_focus ((GtkWindow *) main_window);
@@ -130,16 +136,20 @@ test_bt_main_page_patterns_mouse_click_in_empty_pattern (BT_TEST_ARGS)
   g_object_unref (pattern_page);
   BT_TEST_END;
 }
+END_TEST
+END_TEST
 
 // test entering non note key
-static void
-test_bt_main_page_patterns_non_note_key_press (BT_TEST_ARGS)
+START_TEST (test_bt_main_page_patterns_non_note_key_press)
 {
   BT_TEST_START;
   BtMainPagePatterns *pattern_page;
 
   GST_INFO ("-- arrange --");
-  BtMachine *machine = BT_MACHINE (bt_source_machine_new (song, "gen",
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "gen";
+  BtMachine *machine = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-mono-source", 0L, NULL));
   BtPattern *pattern = bt_pattern_new (song, "pattern-name", 8L, machine);
   g_object_get (G_OBJECT (pages), "patterns-page", &pattern_page, NULL);
@@ -159,16 +169,20 @@ test_bt_main_page_patterns_non_note_key_press (BT_TEST_ARGS)
   g_object_unref (pattern);
   BT_TEST_END;
 }
+END_TEST
+END_TEST
 
 // test that cursor pos stays unchanged on invalid key presses
-static void
-test_bt_main_page_patterns_cursor_pos_on_non_note_key (BT_TEST_ARGS)
+START_TEST (test_bt_main_page_patterns_cursor_pos_on_non_note_key)
 {
   BT_TEST_START;
   BtMainPagePatterns *pattern_page;
 
   GST_INFO ("-- arrange --");
-  BtMachine *machine = BT_MACHINE (bt_source_machine_new (song, "gen",
+  BtMachineConstructorParams cparams;
+  cparams.song = song;
+  cparams.id = "gen";
+  BtMachine *machine = BT_MACHINE (bt_source_machine_new (&cparams,
           "buzztrax-test-mono-source", 0L, NULL));
   BtPattern *pattern = bt_pattern_new (song, "pattern-name", 8L, machine);
   g_object_get (G_OBJECT (pages), "patterns-page", &pattern_page, NULL);
@@ -190,6 +204,8 @@ test_bt_main_page_patterns_cursor_pos_on_non_note_key (BT_TEST_ARGS)
   g_object_unref (pattern);
   BT_TEST_END;
 }
+END_TEST
+END_TEST
 
 
 TCase *

--- a/tests/ui/edit/t-main-page-waves.c
+++ b/tests/ui/edit/t-main-page-waves.c
@@ -47,8 +47,7 @@ case_teardown (void)
 //-- helper
 
 //-- tests
-static void
-test_bt_main_page_wave_missing_playbin (BT_TEST_ARGS)
+START_TEST (test_bt_main_page_wave_missing_playbin)
 {
   BT_TEST_START;
   BtEditApplication *app;
@@ -80,6 +79,7 @@ test_bt_main_page_wave_missing_playbin (BT_TEST_ARGS)
   ck_g_object_final_unref (app);
   BT_TEST_END;
 }
+END_TEST
 
 
 

--- a/tests/ui/edit/t-object-list-model.c
+++ b/tests/ui/edit/t-object-list-model.c
@@ -57,8 +57,7 @@ case_teardown (void)
 
 //-- tests
 
-static void
-test_bt_object_list_model_add_entry (BT_TEST_ARGS)
+START_TEST (test_bt_object_list_model_add_entry)
 {
   BT_TEST_START;
   GST_INFO ("-- arrange --");
@@ -72,13 +71,14 @@ test_bt_object_list_model_add_entry (BT_TEST_ARGS)
   bt_object_list_model_append (model, (GObject *) b);
 
   GST_INFO ("-- assert --");
-  fail_unless (check_has_error_trapped (), NULL);
+  ck_assert (check_has_error_trapped ());
 
   GST_INFO ("-- cleanup --");
   g_object_unref (b);
   g_object_unref (model);
   BT_TEST_END;
 }
+END_TEST
 
 TCase *
 bt_object_list_model_test_case (void)


### PR DESCRIPTION
v0.15.2 is the version of "check" in the latest Ubuntu, and it looks like it needs some changes now to work.

* I deleted some old ifdefs based on different "check" versions as I figure we may as well make a clean break at this point, hope that's ok.
* It seems plain function pointers to tests are no longer acceptable to check, so all tests have been upgraded to use START/END_TEST macros.
* It wasn't necessary, but I translated use of check's deprecated "fail", "fail_if" and "fail_unless" macros to use plain "ck_assert". You might like to look over the "fail_if" calls as I might have gotten too excited and forgotten to negate the logic in those ones.

There are some other fixes in the PR:

* A test for the unique ID logic in #114.
* A fix for #115 is also here.
* Some out-of-tree build fixes in Makefile.am.
* The valgrind make tasks weren't working for me; I added fixes.

I also did find some genuine issues while fixing tests:

* Just a test problem, but registering the bt-sink-bin plugin multiple times during a test run seemed to cause issues.
* Logic I added in PR #109 was causing test timeouts (thanks, tests!), please see the explanation in the change.
* I disabled one test until we can fix issue #111, and there are still two other tests that are segfaulting in the suite but are fine when run individually.
* Some tests in the gst suite are also failing, hope to track those down later.

Thanks for reviewing!