### PR TITLE
Fix version.entities path in index.docbook

### DIFF
--- a/docs/help/bt-edit/C/index.docbook
+++ b/docs/help/bt-edit/C/index.docbook
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE article PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN" "http://www.oasis-open.org/docbook/xml/4.3/docbookx.dtd" [
 <!ENTITY legal SYSTEM "legal.xml">
-<!ENTITY % version-entities SYSTEM "./version.entities">
+<!ENTITY % version-entities SYSTEM "../version.entities">
 %version-entities;
 <!ENTITY app "Buzztrax">
 <!ENTITY rrar "&#8594;">


### PR DESCRIPTION
Since Makefile is running xmllint with `--path C` and the version.entities file is inside C's parent directory, its location needs to be adjusted to `../version.entities`.

Fixes #144