### PR TITLE
Fix my regression (b7d25b0) in sequence loop end/play end handling.

### DIFF
--- a/src/lib/core/sequence.h
+++ b/src/lib/core/sequence.h
@@ -86,4 +86,8 @@ void bt_sequence_insert_full_rows(const BtSequence * const self, const gulong ti
 void bt_sequence_delete_rows(const BtSequence * const self, const gulong time, const glong track, const gulong rows);
 void bt_sequence_delete_full_rows(const BtSequence * const self, const gulong time, const gulong rows);
 
+// This should only be needed by functions such as sequence data paste.
+// It should ideally not be exposed at all, but this will do for now.
+void bt_sequence_resize_data_length (const BtSequence * const self, const gulong length);
+
 #endif // BT_SEQUENCE_H

--- a/src/ui/edit/main-page-sequence.c
+++ b/src/ui/edit/main-page-sequence.c
@@ -1168,7 +1168,7 @@ on_sequence_label_edited (GtkCellRendererText * cellrenderertext,
 
         if (pos >= old_length) {
           new_length = pos + self->priv->bars;
-          g_object_set (self->priv->sequence, "len-patterns", new_length, NULL);
+          bt_sequence_resize_data_length (self->priv->sequence, new_length);
           sequence_calculate_visible_lines (self);
           sequence_update_model_length (self);
 
@@ -3002,7 +3002,7 @@ on_sequence_table_key_press_event (GtkWidget * widget, GdkEventKey * event,
 
           if (row >= length) {
             new_length = row + self->priv->bars;
-            g_object_set (self->priv->sequence, "len-patterns", new_length, NULL);
+            bt_sequence_resize_data_length (self->priv->sequence, new_length);
             sequence_calculate_visible_lines (self);
             sequence_update_model_length (self);
           }
@@ -4328,7 +4328,7 @@ sequence_clipboard_received_func (GtkClipboard * clipboard,
     end = beg + ticks;
 
     if (end > sequence_length)
-      g_object_set (self->priv->sequence, "len-patterns", end, NULL);
+      bt_sequence_resize_data_length (self->priv->sequence, end);
     
     GST_INFO ("pasting from row %d to %d", beg, end);
 

--- a/tests/lib/core/t-sequence.c
+++ b/tests/lib/core/t-sequence.c
@@ -265,7 +265,7 @@ START_TEST (test_bt_sequence_length_reduce_no_truncate)
      values are correctly updated and that no sequence data has been lost. */
   GST_INFO ("-- act --");
   g_object_set (sequence, "length", 4L, NULL);
-  g_object_set (sequence, "len-patterns", 8L, NULL);
+  bt_sequence_resize_data_length (sequence, 8L);
 
   GST_INFO ("-- assert --");
 
@@ -306,7 +306,7 @@ START_TEST (test_bt_sequence_length_reduce_and_persist)
   GST_INFO ("-- act --");
   
   g_object_set (sequence, "length", 4L, NULL);
-  g_object_set (sequence, "len-patterns", 8L, NULL);
+  bt_sequence_resize_data_length (sequence, 8L);
   
   xmlDocPtr const doc = xmlNewDoc (XML_CHAR_PTR ("1.0"));
   xmlNodePtr node = bt_persistence_save (BT_PERSISTENCE (song), NULL, NULL);


### PR DESCRIPTION
Also removed "len-patterns" property setter. This property may not agree to set itself to a value that would cause pattern truncation, so the value supplied to g_object_set may not match g_object_get. Not only does this confuse the automated tests (check_readwrite_long_param) but sequence data size management should ideally be a hidden implementation detail.

Fixes #136.