### PR TITLE
Improve download translation script

### DIFF
--- a/download-translations
+++ b/download-translations
@@ -93,7 +93,7 @@ do
   fi
 done
 
-if [ -n "LANGUAGES_UPDATED" ]; then
+if [ -n "$LANGUAGES_UPDATED" ]; then
   echo "===================================================================="
   echo
   echo "Language codes updated    :$LANGUAGES_UPDATED"
@@ -103,7 +103,7 @@ if [ -n "LANGUAGES_UPDATED" ]; then
   echo
   if [ -n "$LANGUAGES_TO_ADD" ]; then
     CMD_STRING="git add"
-    for d in $LANGUAGES_TO_ADD; do
+    for l in $LANGUAGES_TO_ADD; do
       CMD_STRING="$CMD_STRING po/$l.po"
     done
     CMD_STRING="$CMD_STRING; git commit -m \"add new translations\""

--- a/download-translations
+++ b/download-translations
@@ -30,27 +30,20 @@ warn_msg() {
 }
 
 # check for 'diff' program
-diff --version 2>/dev/null >/dev/null
-if [ $? -ne 0 ]; then
-  err_msg "==== You must have the 'diff' program installed for this script ===="
-fi
+diff --version 2>/dev/null >/dev/null || \
+  err_msg "You must have the 'diff' program installed for this script."
 
 # check for 'wget' program
-wget --version 2>/dev/null >/dev/null
-if [ $? -ne 0 ]; then
-  err_msg "==== You must have the 'wget' program installed for this script ===="
-fi
+wget --version 2>/dev/null >/dev/null || \
+  err_msg "You must have the 'wget' program installed for this script."
 
 # check for 'msguniq' program
-msguniq --version 2>/dev/null >/dev/null
-if [ $? -ne 0 ]; then
-  err_msg "==== You must have the 'gettext' package installed for this script ===="
-fi
+msguniq --version 2>/dev/null >/dev/null || \
+  err_msg "You must have the 'gettext' package installed for this script."
 
 # make sure we're in the top-level directory
-if [ ! -d ./po ]; then
-  err_msg "==== No ./po directory in the current working directory ===="
-fi
+[ -d ./po ] || \
+  err_msg "No ./po directory in the current working directory."
 
 DOMAIN="buzztrax"
 

--- a/download-translations
+++ b/download-translations
@@ -16,15 +16,22 @@ LANGUAGES=\
 
 # check for 'diff' program
 diff --version 2>/dev/null >/dev/null
-if [ ! $? ]; then
+if [ $? -ne 0 ]; then
   echo "==== You must have the 'diff' program installed for this script ===="
   exit 1
 fi
 
 # check for 'wget' program
 wget --version 2>/dev/null >/dev/null
-if [ ! $? ]; then
+if [ $? -ne 0 ]; then
   echo "==== You must have the 'wget' program installed for this script ===="
+  exit 1
+fi
+
+# check for 'msguniq' program
+msguniq --version 2>/dev/null >/dev/null
+if [ $? -ne 0 ]; then
+  echo "==== You must have the 'gettext' package installed for this script ===="
   exit 1
 fi
 

--- a/download-translations
+++ b/download-translations
@@ -91,16 +91,15 @@ do
       # website, so it's probably a new translation
       echo "$l.po: new language"
       mv $PO_FILENAME "po/$l.po"
-      LANGUAGES_UPDATED="$LANGUAGES_UPDATED $l"
       LANGUAGES_TO_ADD="$LANGUAGES_TO_ADD $l"
     fi
   else
     rm -f $PO_FILENAME
-    echo "$l.po: failure (does probably not exist)"
+    echo "$l.po: failure (probably does not exist yet)"
   fi
 done
 
-if [ -n "$LANGUAGES_UPDATED" ]; then
+if [ -n "$LANGUAGES_UPDATED" ] || [ -n "$LANGUAGES_TO_ADD" ]; then
   echo "===================================================================="
   echo
   echo "Language codes updated    :$LANGUAGES_UPDATED"
@@ -108,19 +107,31 @@ if [ -n "$LANGUAGES_UPDATED" ]; then
   echo
   echo "Source: http://translationproject.org/latest/$DOMAIN/"
   echo
+  if [ -n "$LANGUAGES_UPDATED" ]; then
+    CMD_STRING="git add"
+    for l in $LANGUAGES_UPDATED; do
+      CMD_STRING="$CMD_STRING po/$l.po"
+    done
+    CMD_STRING="$CMD_STRING; git commit -m 'po: update translations'"
+    echo "To commit the updated translations, please run:"
+    echo
+    echo "  $CMD_STRING"
+    echo
+    echo
+  fi
   if [ -n "$LANGUAGES_TO_ADD" ]; then
+    echo "Edit 'po/LINGUAS' adding the following new language codes:"
+    echo
+    echo "  $LANGUAGES_TO_ADD"
+    echo
     CMD_STRING="git add"
     for l in $LANGUAGES_TO_ADD; do
       CMD_STRING="$CMD_STRING po/$l.po"
     done
-    CMD_STRING="$CMD_STRING; git commit -m \"add new translations\""
-    echo "Please run"
+    CMD_STRING="$CMD_STRING po/LINGUAS; git commit -m 'po: add new translations'"
+    echo "and now add the new translations, please run:"
     echo
     echo "  $CMD_STRING"
-    echo
-    echo "now and add the following language codes to the po/LINGUAS file:"
-    echo
-    echo "  $LANGUAGES_TO_ADD"
     echo
     echo
   fi

--- a/download-translations
+++ b/download-translations
@@ -6,10 +6,10 @@
 # We need to check all languages, not only po/LINGUAS, since there might be
 # new translations
 LANGUAGES=\
-"af am ar az be bg pt_BR bs ca zh_CN cs cy da de el eo es et eu fa fi fr "\
-"ga en_GB gl gu he hi zh_HK hr hu id is it ja ko ku ky lg lt lv mk mn ms "\
-"mt nb ne nl nn or pa pl pt rm ro ru rw sk sl sq sr sv ta tq th tk "\
-"tr zh_TW uk ven vi wa xh zu"
+"ab af an ar ast be bg bn bn_IN ca ckb crh cs da de el en_GB eo es et eu "\
+"fa fi fr fur ga gd gl gu he hi hr hu hy id is it ja ka kk kn ko ku ky lg "\
+"lt lv mk ml mn mr ms mt nb ne nl nn or pa pl pt pt_BR ro ru rw sk sl sq "\
+"sr sv sw ta te tg th tr uk ur vi wa wo zh_CN zh_HK zh_TW"
 
 # for testing/debugging:
 #LANGUAGES="es fr hu sv pl xx"

--- a/download-translations
+++ b/download-translations
@@ -14,31 +14,42 @@ LANGUAGES=\
 # for testing/debugging:
 #LANGUAGES="es fr hu sv pl xx"
 
+# print error message and exit; prefix problem matcher when in GitHub Actions
+err_msg() {
+  local prefix
+  [ -n "$CI" ] && prefix="::error::"
+  echo $prefix"$*" >&2
+  exit 1
+}
+
+# print warning message; prefix problem matcher when in GitHub Actions
+warn_msg() {
+  local prefix
+  [ -n "$CI" ] && prefix="::warning::"
+  echo $prefix"$*" >&2
+}
+
 # check for 'diff' program
 diff --version 2>/dev/null >/dev/null
 if [ $? -ne 0 ]; then
-  echo "==== You must have the 'diff' program installed for this script ===="
-  exit 1
+  err_msg "==== You must have the 'diff' program installed for this script ===="
 fi
 
 # check for 'wget' program
 wget --version 2>/dev/null >/dev/null
 if [ $? -ne 0 ]; then
-  echo "==== You must have the 'wget' program installed for this script ===="
-  exit 1
+  err_msg "==== You must have the 'wget' program installed for this script ===="
 fi
 
 # check for 'msguniq' program
 msguniq --version 2>/dev/null >/dev/null
 if [ $? -ne 0 ]; then
-  echo "==== You must have the 'gettext' package installed for this script ===="
-  exit 1
+  err_msg "==== You must have the 'gettext' package installed for this script ===="
 fi
 
 # make sure we're in the top-level directory
 if [ ! -d ./po ]; then
-  echo "==== No ./po directory in the current working directory ===="
-  exit 1
+  err_msg "==== No ./po directory in the current working directory ===="
 fi
 
 DOMAIN="buzztrax"
@@ -64,7 +75,7 @@ do
                               --to-code=UTF-8; then
         mv $PO_FILENAME.utf8 $PO_FILENAME
       else
-        echo "**** $l: conversion from $CHARSET to UTF-8 failed ****"
+        warn_msg "**** $l: conversion from $CHARSET to UTF-8 failed ****"
       fi
     fi
     if [ -f "po/$l.po" ]; then


### PR DESCRIPTION
The reasons are explained in the commits, but here is a summary:
- Fix issues in my previous "variables rename" commit
- Fix verification of binary availability, and include check for msguniq as gettext package could not be available
- Make LANGUAGES_UPDATED variable exclusively for updated translation files, changing the final info output for that fact
- Add language codes from Translation Project that are not listed in the script
- Add prefixes `::error::some error text here` and `::warning::some warning here` to include annotation when running in GitHub Actions (which is a WIP right now)